### PR TITLE
fix(bug): the issue #58

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
+	github.com/hashicorp/terraform-plugin-go v0.26.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.0
 	github.com/hashicorp/terraform-plugin-testing v1.11.0
@@ -45,7 +46,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.22.0 // indirect
 	github.com/hashicorp/terraform-json v0.24.0 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.26.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.4 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -338,6 +338,7 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	state.populate(cluster)
+	state.Timeouts = plan.Timeouts
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -74,8 +74,8 @@ resource "zillizcloud_cluster" "test" {
   cu_type      = "Performance-optimized"             # The type of compute unit, optimized for performance
   project_id   = data.zillizcloud_project.default.id
   timeouts {
-    create = "10m"
-	update = "10m"
+	create = "20m"
+	update = "20m"
   }
 }
 `,
@@ -113,6 +113,9 @@ resource "zillizcloud_cluster" "test" {
 			// Test update
 			{
 				Config: provider.ProviderConfig + `
+				data "zillizcloud_project" "default" {
+				}
+
 				resource "zillizcloud_cluster" "test" {
 					cluster_name = "a-standard-cluster"
 					plan         = "Standard"
@@ -120,8 +123,8 @@ resource "zillizcloud_cluster" "test" {
 					cu_type      = "Performance-optimized"             # The type of compute unit, optimized for performance
 					project_id   = data.zillizcloud_project.default.id
 					timeouts {
-						create = "10m"
-						update = "10m"
+						create = "20m"
+						update = "20m"
 					}
 				}
 				`,


### PR DESCRIPTION
fix: #58

ZILLIZCLOUD_API_KEY=xx TF_ACC=1 go test -count=1 -v -run TestAccClusterResourceStandardPlan
=== RUN   TestAccClusterResourceStandardPlan
--- PASS: TestAccClusterResourceStandardPlan (300.70s)
PASS
ok      github.com/zilliztech/terraform-provider-zillizcloud/internal/provider  301.068s