### PR TITLE
chore(Idempotent): write down id right after creating

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,3 +19,7 @@ lint:
 
 fmt:
 	go fmt ./...
+
+.PHONY: mock-server
+mock-server:
+	cd mock-server && go run main.go

--- a/internal/cluster/cluster_resource.go
+++ b/internal/cluster/cluster_resource.go
@@ -295,9 +295,12 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	data.ClusterId = cluster.ClusterId
 	data.Username = cluster.Username
 	data.Password = cluster.Password
 	data.Prompt = cluster.Prompt
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 	// Wait for cluster to be RUNNING
 	// Create() is passed a default timeout to use if no value


### PR DESCRIPTION
This pull request introduces a new mock server utility and fixes the cluster creation logic to ensure the resource state is properly set after creation. The most important changes are:

**Development workflow improvements:**

* Added a new `mock-server` target to the `GNUmakefile` to allow running a mock server for local development and testing.

**Cluster resource creation fixes:**

* Updated the `Create` method in `cluster_resource.go` to set the `ClusterId` on the resource data and immediately update the Terraform state after creating a cluster. This ensures the resource state is correctly initialized for downstream operations.