### PR TITLE
chore: no operation when plan is upgraded

### DIFF
--- a/internal/cluster/cluster_resource.go
+++ b/internal/cluster/cluster_resource.go
@@ -424,6 +424,43 @@ func (r *ClusterResource) handleLabelsUpdate(ctx context.Context, plan, state Cl
 	return diags
 }
 
+func getPlanRank(plan string) int {
+	switch zilliz.Plan(plan) {
+	case zilliz.FreePlan:
+		return 0
+	case zilliz.ServerlessPlan:
+		return 1
+	case zilliz.StandardPlan:
+		return 2
+	case zilliz.EnterprisePlan:
+		return 3
+	default:
+		return -1
+	}
+}
+
+func validatePlanUpgrade(currentPlan, newPlan string) error {
+	if currentPlan == newPlan {
+		return nil
+	}
+
+	currentRank := getPlanRank(currentPlan)
+	newRank := getPlanRank(newPlan)
+
+	if currentRank == -1 {
+		return fmt.Errorf("invalid current plan: %s", currentPlan)
+	}
+	if newRank == -1 {
+		return fmt.Errorf("invalid new plan: %s", newPlan)
+	}
+
+	if newRank < currentRank {
+		return fmt.Errorf("plan downgrade is not allowed. Cannot change from %s to %s. Only plan upgrades are supported", currentPlan, newPlan)
+	}
+
+	return nil
+}
+
 func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	tflog.Info(ctx, "Update Cluster...")
 
@@ -449,6 +486,18 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if plan.isClusterPlanChanged(state) {
+		// Validate plan upgrade - only allow upgrades, not downgrades
+		if err := validatePlanUpgrade(state.Plan.ValueString(), plan.Plan.ValueString()); err != nil {
+			resp.Diagnostics.AddError("Invalid Plan Change", err.Error())
+			return
+		}
+		// no op - plan changes are not yet supported by the API
+		// directly set the plan to the new plan
+		// TODO: implement later on when openapi is ready
+		state.Plan = plan.Plan
 	}
 
 	if plan.isCuSizeChanged(state) {

--- a/internal/cluster/model.go
+++ b/internal/cluster/model.go
@@ -48,7 +48,6 @@ func (c *ClusterResourceModel) populate(input *ClusterResourceModel) {
 	c.ConnectAddress = input.ConnectAddress
 	c.PrivateLinkAddress = input.PrivateLinkAddress
 	c.CreateTime = input.CreateTime
-	c.Plan = input.Plan
 	c.Replica = input.Replica
 	c.CuSize = input.CuSize
 	c.CuType = input.CuType
@@ -67,6 +66,10 @@ func (c *ClusterResourceModel) populate(input *ClusterResourceModel) {
 // Comparison methods for ClusterResourceModel
 func (c *ClusterResourceModel) isCuSizeChanged(other ClusterResourceModel) bool {
 	return c.CuSize.ValueInt64() != other.CuSize.ValueInt64()
+}
+
+func (c *ClusterResourceModel) isClusterPlanChanged(other ClusterResourceModel) bool {
+	return c.Plan.ValueString() != other.Plan.ValueString()
 }
 
 func (c *ClusterResourceModel) isReplicaChanged(other ClusterResourceModel) bool {


### PR DESCRIPTION
This pull request introduces logic to validate and restrict changes to the `plan` field for clusters, ensuring that only plan upgrades (not downgrades) are permitted. It also adds comprehensive tests to verify this behavior and updates test utilities accordingly.

**Plan change validation and enforcement:**

- Added `getPlanRank` and `validatePlanUpgrade` helper functions in `cluster_resource.go` to determine plan hierarchy and prevent downgrades, allowing only plan upgrades. (`internal/cluster/cluster_resource.go` [internal/cluster/cluster_resource.goR427-R463](diffhunk://#diff-10b1fe1d02136e4a796a1cff0f979142ef11ae2764f4ecde0fa565309da66160R427-R463))
- Updated the `Update` method in `ClusterResource` to use the new validation logic when the plan changes, returning an error if a downgrade is attempted. (`internal/cluster/cluster_resource.go` [internal/cluster/cluster_resource.goR491-R502](diffhunk://#diff-10b1fe1d02136e4a796a1cff0f979142ef11ae2764f4ecde0fa565309da66160R491-R502))
- Added `isClusterPlanChanged` method to `ClusterResourceModel` to detect plan changes. (`internal/cluster/model.go` [internal/cluster/model.goR71-R74](diffhunk://#diff-26f09143a3b353cb8cf3f3cebc2fd1d2f91a129447bc4c847539d1f3f7937f50R71-R74))

**Testing enhancements:**

- Added two new acceptance tests: one to verify successful plan upgrades and another to ensure downgrades are prevented and return appropriate errors. (`internal/cluster/cluster_resource_test.go` [internal/cluster/cluster_resource_test.goR325-R453](diffhunk://#diff-f7ed30a5856dd3b3074683accc67b4cc8d59b274232dfc67bf35b33fb7e2a8a5R325-R453))
- Updated the main test runner to include the new plan change tests. (`internal/cluster/cluster_resource_test.go` [internal/cluster/cluster_resource_test.goR20-R24](diffhunk://#diff-f7ed30a5856dd3b3074683accc67b4cc8d59b274232dfc67bf35b33fb7e2a8a5R20-R24))
- Updated `ImportStateVerifyIgnore` lists in relevant tests to include the `plan` field, preventing false negatives during import state verification. (`internal/cluster/cluster_resource_test.go` [[1]](diffhunk://#diff-f7ed30a5856dd3b3074683accc67b4cc8d59b274232dfc67bf35b33fb7e2a8a5L56-R62) [[2]](diffhunk://#diff-f7ed30a5856dd3b3074683accc67b4cc8d59b274232dfc67bf35b33fb7e2a8a5L103-R109) [[3]](diffhunk://#diff-f7ed30a5856dd3b3074683accc67b4cc8d59b274232dfc67bf35b33fb7e2a8a5L161-R167)

**Test utility import:**

- Added the `regexp` package import to support error matching in tests. (`internal/cluster/cluster_resource_test.go` [internal/cluster/cluster_resource_test.goR5](diffhunk://#diff-f7ed30a5856dd3b3074683accc67b4cc8d59b274232dfc67bf35b33fb7e2a8a5R5))