### PR TITLE
fix:the requestid is missing

### DIFF
--- a/client/zilliz.go
+++ b/client/zilliz.go
@@ -346,12 +346,13 @@ func (c *Client) doRequest(req *http.Request, v any) error {
 	if c.logHttpTraffic {
 		c.logger.LogResponse(res, bodyBytes)
 	}
+	requestId := res.Header.Get("requestid")
 
 	if res.StatusCode >= http.StatusBadRequest {
-		return fmt.Errorf("http status code: %d, error: %w", res.StatusCode, parseError(bytes.NewReader(bodyBytes)))
+		return fmt.Errorf("http status code: %d, error: %w, requestId: %s", res.StatusCode, parseError(bytes.NewReader(bodyBytes)), requestId)
 	}
 
-	return c.decodeResponse(bytes.NewReader(bodyBytes), res.Header.Get("requestid"), v)
+	return c.decodeResponse(bytes.NewReader(bodyBytes), requestId, v)
 }
 
 func parseError(body io.Reader) error {


### PR DESCRIPTION
This pull request makes a targeted improvement to error handling in the `Client`'s HTTP request logic. Now, when an HTTP error occurs, the error message will include the `requestId` from the response headers, making it easier to trace and debug issues.

**Error handling and logging:**

* Updated the `doRequest` method in `client/zilliz.go` to extract the `requestId` from the response headers and include it in both error messages and response decoding, improving traceability for failed HTTP requests.