### PR TITLE
feat: support for updating the cluster name after creation 

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -48,6 +48,20 @@ func (c *Client) ModifyCluster(clusterId string, params *ModifyClusterParams) (*
 	return &response.Data.ClusterId, err
 }
 
+// add or remove cu
+type ModifyPropertiesParams struct {
+	ClusterName string `json:"clusterName"`
+}
+
+func (c *Client) ModifyClusterProperties(clusterId string, params *ModifyPropertiesParams) (*string, error) {
+	var response zillizResponse[ClusterResponse]
+	err := c.do("POST", "clusters/"+clusterId+"/modifyProperties", params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response.Data.ClusterId, err
+}
+
 // modifyReplica.
 type ModifyReplicaParams struct {
 	Replica int `json:"replica"`

--- a/internal/cluster/cluster_resource_test.go
+++ b/internal/cluster/cluster_resource_test.go
@@ -224,7 +224,7 @@ resource "zillizcloud_cluster" "test" {
 				}
 
 				resource "zillizcloud_cluster" "test" {
-					cluster_name = "a-standard-cluster"
+					cluster_name = "a-standard-cluster-renamed"        # change the cluster name
 					region_id    = "aws-us-west-2"
 					plan         = "Standard"
 					cu_size      = "2"                                 # change the cu_size
@@ -238,7 +238,7 @@ resource "zillizcloud_cluster" "test" {
 				}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cluster_name", "a-standard-cluster"),
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cluster_name", "a-standard-cluster-renamed"),
 					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "plan", "Standard"),
 					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "status", "RUNNING"),
 					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cu_size", "2"),

--- a/internal/cluster/model.go
+++ b/internal/cluster/model.go
@@ -77,6 +77,10 @@ func (c *ClusterResourceModel) isLabelsChanged(other ClusterResourceModel) bool 
 	return !c.Labels.Equal(other.Labels)
 }
 
+func (c *ClusterResourceModel) isClusterNameChanged(other ClusterResourceModel) bool {
+	return c.ClusterName.ValueString() != other.ClusterName.ValueString()
+}
+
 func (c *ClusterResourceModel) isStatusChangeRequired(other ClusterResourceModel) bool {
 	if !c.DesiredStatus.IsNull() && c.DesiredStatus.ValueString() != "" {
 		desiredStatus := c.DesiredStatus.ValueString()

--- a/internal/cluster/store.go
+++ b/internal/cluster/store.go
@@ -19,6 +19,7 @@ type ClusterStore interface {
 	SuspendCluster(ctx context.Context, clusterId string) error
 	ResumeCluster(ctx context.Context, clusterId string) error
 	UpdateLabels(ctx context.Context, clusterId string, labels map[string]string) error
+	ModifyClusterProperties(ctx context.Context, clusterId string, clusterName string) error
 }
 
 var _ ClusterStore = (*ClusterStoreImpl)(nil)
@@ -177,6 +178,13 @@ func (c *ClusterStoreImpl) GetLabels(ctx context.Context, clusterId string) (typ
 		return types.MapValueMust(types.StringType, map[string]attr.Value{}), err
 	}
 	return convertLabelsToTypesMap(labels), nil
+}
+
+func (c *ClusterStoreImpl) ModifyClusterProperties(ctx context.Context, clusterId string, clusterName string) error {
+	_, err := c.client.ModifyClusterProperties(clusterId, &zilliz.ModifyPropertiesParams{
+		ClusterName: clusterName,
+	})
+	return err
 }
 
 // convertLabelsToTypesMap converts a map[string]string into a Terraform types.Map of strings.


### PR DESCRIPTION
This pull request adds support for updating the cluster name after creation in the Zilliz Cloud cluster resource. The changes introduce new API methods, update the resource model and store implementation, and add corresponding test coverage to ensure cluster name updates work correctly.

**Cluster name update support:**

* Added a new method `ModifyClusterProperties` to the client (`client/cluster.go`) for updating cluster properties, including the cluster name.
* Implemented the `ModifyClusterProperties` method in the `ClusterStore` interface and its concrete implementation to call the client method. [[1]](diffhunk://#diff-578da58b211e381313acfa188951de2bbf2161c3d361563224367f1c8ffefcc1R22) [[2]](diffhunk://#diff-578da58b211e381313acfa188951de2bbf2161c3d361563224367f1c8ffefcc1R183-R189)
* Added logic to detect and handle cluster name changes in the resource model and update flow (`internal/cluster/model.go`, `internal/cluster/cluster_resource.go`). [[1]](diffhunk://#diff-26f09143a3b353cb8cf3f3cebc2fd1d2f91a129447bc4c847539d1f3f7937f50R80-R83) [[2]](diffhunk://#diff-10b1fe1d02136e4a796a1cff0f979142ef11ae2764f4ecde0fa565309da66160R427-R438) [[3]](diffhunk://#diff-10b1fe1d02136e4a796a1cff0f979142ef11ae2764f4ecde0fa565309da66160R493-R499)

**Test coverage and schema adjustments:**

* Updated the cluster resource test to verify that the cluster name can be changed and is reflected in the resource state. [[1]](diffhunk://#diff-f7ed30a5856dd3b3074683accc67b4cc8d59b274232dfc67bf35b33fb7e2a8a5L227-R227) [[2]](diffhunk://#diff-f7ed30a5856dd3b3074683accc67b4cc8d59b274232dfc67bf35b33fb7e2a8a5L241-R241)
* Removed the `RequiresReplace` plan modifier from the `cluster_name` schema attribute to allow in-place updates instead of requiring resource replacement.