### PR TITLE
feat: support add nlb sg for byoc milvus

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -19,7 +19,35 @@ type ClusterResponse struct {
 	ClusterId string `json:"clusterId"`
 }
 
-//suspend cluster
+type UpsertSecurityGroupsParams struct {
+	Ids []string `json:"ids"`
+}
+
+// upsert security groups
+func (c *Client) UpsertSecurityGroups(clusterId string, params *UpsertSecurityGroupsParams) (*string, error) {
+	var response zillizResponse[ClusterResponse]
+	err := c.do("PUT", "clusters/"+clusterId+"/securityGroups", params, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response.Data.ClusterId, nil
+}
+
+type GetSecurityGroupsResponse struct {
+	Ids []string `json:"ids"`
+}
+
+// get security groups
+func (c *Client) GetSecurityGroups(clusterId string) ([]string, error) {
+	var response zillizResponse[GetSecurityGroupsResponse]
+	err := c.do("GET", "clusters/"+clusterId+"/securityGroups", nil, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.Data.Ids, nil
+}
+
+// suspend cluster
 
 func (c *Client) SuspendCluster(clusterId string) (*string, error) {
 	var response zillizResponse[ClusterResponse]

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -75,6 +75,7 @@ resource "zillizcloud_cluster" "enterprise_plan_cluster" {
 - `cu_type` (String) The type of the CU used for the Zilliz Cloud cluster to be created. A compute unit (CU) is the physical resource unit for cluster deployment. Different CU types comprise varying combinations of CPU, memory, and storage. Available options are Performance-optimized, Capacity-optimized, and Extended-capacity.
 - `desired_status` (String) The desired status of the cluster. Possible values are RUNNING and SUSPENDED. Defaults to RUNNING.
 - `labels` (Map of String) A map of labels to assign to the cluster. Labels are key-value pairs that can be used to organize and categorize clusters.
+- `load_balancer_security_groups` (Set of String) A set of security group IDs to associate with the load balancer of the cluster.
 - `plan` (String) The plan tier of the Zilliz Cloud service. Available options are Serverless, Standard and Enterprise.
 - `region_id` (String) The ID of the region where the cluster exists.
 - `replica` (Number) The number of replicas for the cluster. Defaults to 1.

--- a/internal/cluster/model.go
+++ b/internal/cluster/model.go
@@ -32,6 +32,7 @@ type ClusterResourceModel struct {
 	PrivateLinkAddress types.String   `tfsdk:"private_link_address"`
 	CreateTime         types.String   `tfsdk:"create_time"`
 	Labels             types.Map      `tfsdk:"labels"`
+	SecurityGroups     types.Set      `tfsdk:"load_balancer_security_groups"`
 	Replica            types.Int64    `tfsdk:"replica"`
 	Timeouts           timeouts.Value `tfsdk:"timeouts"`
 }
@@ -79,6 +80,10 @@ func (c *ClusterResourceModel) isLabelsChanged(other ClusterResourceModel) bool 
 
 func (c *ClusterResourceModel) isClusterNameChanged(other ClusterResourceModel) bool {
 	return c.ClusterName.ValueString() != other.ClusterName.ValueString()
+}
+
+func (c *ClusterResourceModel) isSecurityGroupsChanged(other ClusterResourceModel) bool {
+	return !c.SecurityGroups.Equal(other.SecurityGroups)
 }
 
 func (c *ClusterResourceModel) isStatusChangeRequired(other ClusterResourceModel) bool {

--- a/mock-server/main.go
+++ b/mock-server/main.go
@@ -28,6 +28,8 @@ func main() {
 			clusters.POST("/:clusterId/modifyProperties", byoc_project.ModifyClusterProperties)
 			clusters.GET("/:clusterId/labels", byoc_project.GetLabels)
 			clusters.PUT("/:clusterId/labels", byoc_project.UpdateLabels)
+			clusters.GET("/:clusterId/securityGroups", byoc_project.GetSecurityGroups)
+			clusters.PUT("/:clusterId/securityGroups", byoc_project.UpsertSecurityGroups)
 			clusters.DELETE("/:clusterId/drop", byoc_project.DropCluster)
 		}
 		byoc := v2.Group("/byoc")

--- a/mock-server/pkg/byoc_project/model.go
+++ b/mock-server/pkg/byoc_project/model.go
@@ -382,6 +382,7 @@ type DedicatedClusterResponse struct {
 	SnapshotNumber     int               `json:"snapshotNumber"`
 	CreateProgress     int               `json:"createProgress"`
 	Labels             map[string]string `json:"labels"`
+	SecurityGroups     []string          `json:"securityGroups"`
 }
 
 type Project struct {
@@ -461,4 +462,13 @@ type FreeClusterResponse struct {
 	SnapshotNumber     int               `json:"snapshotNumber"`
 	CreateProgress     int               `json:"createProgress"`
 	Labels             map[string]string `json:"labels"`
+}
+
+// Security Groups request/response types
+type UpsertSecurityGroupsRequest struct {
+	Ids []string `json:"ids"`
+}
+
+type GetSecurityGroupsResponse struct {
+	Ids []string `json:"ids,omitempty"`
 }


### PR DESCRIPTION
This pull request adds support for managing security groups associated with a cluster's load balancer. It introduces new API client methods, updates the Terraform resource schema, and implements logic for creating, updating, and reading security groups as part of the cluster lifecycle.

**Security Group Management Integration:**

* Added new API client methods `UpsertSecurityGroups` and `GetSecurityGroups` in `client/cluster.go` to allow updating and retrieving security groups for a cluster.
* Updated the `ClusterStore` interface and its implementation to support upserting and fetching security groups, including conversion helpers for Terraform types. [[1]](diffhunk://#diff-578da58b211e381313acfa188951de2bbf2161c3d361563224367f1c8ffefcc1R23-R24) [[2]](diffhunk://#diff-578da58b211e381313acfa188951de2bbf2161c3d361563224367f1c8ffefcc1R193-R207) [[3]](diffhunk://#diff-578da58b211e381313acfa188951de2bbf2161c3d361563224367f1c8ffefcc1R221-R234)

**Terraform Resource Schema and Lifecycle Updates:**

* Added a new `load_balancer_security_groups` attribute to the `ClusterResourceModel` and the Terraform schema, enabling users to specify security groups. [[1]](diffhunk://#diff-26f09143a3b353cb8cf3f3cebc2fd1d2f91a129447bc4c847539d1f3f7937f50R35) [[2]](diffhunk://#diff-10b1fe1d02136e4a796a1cff0f979142ef11ae2764f4ecde0fa565309da66160R194-R198)
* Implemented logic in the resource's create and update methods to apply security group changes after cluster creation and during updates, including a helper method to detect and process changes. [[1]](diffhunk://#diff-10b1fe1d02136e4a796a1cff0f979142ef11ae2764f4ecde0fa565309da66160R321-R328) [[2]](diffhunk://#diff-10b1fe1d02136e4a796a1cff0f979142ef11ae2764f4ecde0fa565309da66160R459-R481) [[3]](diffhunk://#diff-10b1fe1d02136e4a796a1cff0f979142ef11ae2764f4ecde0fa565309da66160R543-R550) [[4]](diffhunk://#diff-26f09143a3b353cb8cf3f3cebc2fd1d2f91a129447bc4c847539d1f3f7937f50R85-R88)
* Enhanced the resource's read method to fetch and set the current security groups in state, ensuring accurate Terraform state representation.