### PR TITLE
fix(bug): can not get autoscaling and arch from api

### DIFF
--- a/internal/provider/byoc/byoc_projects_resource.go
+++ b/internal/provider/byoc/byoc_projects_resource.go
@@ -249,7 +249,14 @@ func (r *BYOCProjectResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	data.refresh(model)
+	//BUG: get the auto scaling and arch from the local state, since they are not returned by the API
+	model.Instances.AutoScaling = data.Instances.AutoScaling
+	model.Instances.Arch = data.Instances.Arch
+
+	data.AWS = model.AWS
+	data.Instances = model.Instances
+	data.Status = model.Status
+	data.DataPlaneID = model.DataPlaneID
 
 	tflog.Info(ctx, fmt.Sprintf("Read BYOC Project response: %+v", data))
 

--- a/internal/provider/byoc/model.go
+++ b/internal/provider/byoc/model.go
@@ -60,14 +60,6 @@ type InstancesConfig struct {
 	Arch        types.String `tfsdk:"arch"`
 }
 
-func (data *BYOCProjectResourceModel) refresh(input BYOCProjectResourceModel) {
-	data.AWS = input.AWS
-	data.Instances = input.Instances
-	data.Status = input.Status
-	data.DataPlaneID = input.DataPlaneID
-	// data.Name = input.Name
-}
-
 type BYOCProjectStatus int
 
 const (


### PR DESCRIPTION
This pull request addresses a bug in the BYOC project resource's read logic by ensuring that the `auto scaling` and `arch` fields are correctly preserved from the local state, since they are not returned by the API. Additionally, the now-unnecessary `refresh` method is removed to simplify the code.

Bug fix for state handling:

* In `byoc_projects_resource.go`, updated the `Read` function to explicitly copy `AutoScaling` and `Arch` from the local state to the model, ensuring these fields are retained when the API does not return them.

Codebase simplification:

* In `model.go`, removed the unused `refresh` method from `BYOCProjectResourceModel`, as its logic is now handled directly in the `Read` function.