### PR TITLE
feat(mock-server): support project level upgrading

### DIFF
--- a/mock-server/PROJECT_ENDPOINTS.md
+++ b/mock-server/PROJECT_ENDPOINTS.md
@@ -1,0 +1,238 @@
+# Project Endpoints Documentation
+
+This document describes the standard project endpoints added to the mock server.
+
+## Overview
+
+The mock server now supports standard project operations that mirror the Zilliz Cloud API for managing projects. These endpoints complement the existing BYOC (Bring Your Own Cloud) project endpoints.
+
+## Endpoints
+
+### 1. Create Project
+**POST** `/v2/projects`
+
+Creates a new standard project.
+
+**Request Body:**
+```json
+{
+  "projectName": "my-project",
+  "plan": "Standard"
+}
+```
+
+**Fields:**
+- `projectName` (required): Name of the project
+- `plan` (optional): Plan type (e.g., "Standard", "Enterprise", "Business Critical", "BYOC"). Defaults to "Enterprise" if not specified.
+
+**Response:**
+```json
+{
+  "code": 0,
+  "data": "proj-abc123def456789012345"
+}
+```
+
+Returns the newly created project ID.
+
+---
+
+### 2. List Projects
+**GET** `/v2/projects`
+
+Lists all projects in the account.
+
+**Response:**
+```json
+{
+  "code": 0,
+  "data": [
+    {
+      "projectName": "Default Project",
+      "projectId": "proj-ebc5ac7f430702aec8c57b",
+      "instanceCount": 0,
+      "createTimeMilli": 1703745469000,
+      "plan": "Enterprise"
+    },
+    {
+      "projectName": "my-project",
+      "projectId": "proj-abc123def456789012345",
+      "instanceCount": 0,
+      "createTimeMilli": 1730000000000,
+      "plan": "Standard"
+    }
+  ]
+}
+```
+
+---
+
+### 3. Get Project by ID
+**GET** `/v2/projects/:projectId`
+
+Retrieves a specific project by its ID.
+
+**URL Parameters:**
+- `projectId`: The project ID
+
+**Response:**
+```json
+{
+  "code": 0,
+  "data": {
+    "projectName": "my-project",
+    "projectId": "proj-abc123def456789012345",
+    "instanceCount": 0,
+    "createTimeMilli": 1730000000000,
+    "plan": "Standard"
+  }
+}
+```
+
+**Error Response (404):**
+```json
+{
+  "code": 404,
+  "message": "Project with ID proj-xyz not found"
+}
+```
+
+---
+
+### 4. Upgrade Project Plan
+**PATCH** `/v2/projects/:projectId/plan`
+
+Upgrades the plan for an existing project.
+
+**URL Parameters:**
+- `projectId`: The project ID
+
+**Request Body:**
+```json
+{
+  "plan": "Enterprise"
+}
+```
+
+**Response:**
+```json
+{
+  "code": 0,
+  "data": "Project proj-abc123def456789012345 plan upgraded to Enterprise"
+}
+```
+
+---
+
+### 5. Delete Project
+**DELETE** `/v2/projects/:projectId`
+
+Deletes a project.
+
+**URL Parameters:**
+- `projectId`: The project ID
+
+**Response:**
+```json
+{
+  "code": 0,
+  "data": "Project proj-abc123def456789012345 deleted successfully"
+}
+```
+
+**Error Response (404):**
+```json
+{
+  "code": 404,
+  "message": "Project with ID proj-xyz not found"
+}
+```
+
+---
+
+## Data Model
+
+### Project Structure
+
+```go
+type Project struct {
+    ProjectName     string `json:"projectName"`     // Name of the project
+    ProjectId       string `json:"projectId"`       // Unique identifier (format: proj-{uuid})
+    InstanceCount   int64  `json:"instanceCount"`   // Number of cluster instances
+    CreateTimeMilli int64  `json:"createTimeMilli"` // Creation timestamp in milliseconds
+    Plan            string `json:"plan"`            // Plan type (Standard, Enterprise, etc.)
+}
+```
+
+## Testing
+
+A test script is provided to verify all project endpoints:
+
+```bash
+# Start the mock server
+cd mock-server
+go run main.go
+
+# In another terminal, run the test script
+./test/project_test.sh
+```
+
+The test script performs the following operations:
+1. Lists all projects (initial state with default project)
+2. Creates a new project with Standard plan
+3. Gets the created project by ID
+4. Lists all projects (should now have 2)
+5. Upgrades the project plan to Enterprise
+6. Verifies the plan upgrade
+7. Creates a project with default plan (should default to Enterprise)
+8. Verifies the default plan
+9. Deletes a project
+10. Attempts to get the deleted project (should return 404)
+11. Lists all projects (deleted project should not appear)
+
+## Default Data
+
+The mock server initializes with one default project:
+
+```json
+{
+  "projectName": "Default Project",
+  "projectId": "proj-ebc5ac7f430702aec8c57b",
+  "instanceCount": 0,
+  "createTimeMilli": 1703745469000,
+  "plan": "Enterprise"
+}
+```
+
+## Implementation Details
+
+### Files Modified/Created
+
+1. **Created: `pkg/byoc_project/project.go`**
+   - Contains all handler functions for project operations
+   - Implements thread-safe operations using the existing `safeStore`
+
+2. **Modified: `pkg/byoc_project/model.go`**
+   - Updated `Project` struct with `Plan` and `CreateTimeMilli` fields
+   - Added `CreateProjectRequest` and `UpgradeProjectPlanRequest` types
+
+3. **Modified: `pkg/byoc_project/store.go`**
+   - Updated default project initialization with `Plan` field
+   - Added `Delete()` method to `safeStore` for project deletion
+
+4. **Modified: `pkg/byoc_project/cluster.go`**
+   - Removed duplicate `GetProjects()` function (moved to project.go)
+
+5. **Modified: `main.go`**
+   - Added routes for standard project endpoints under `/v2/projects`
+
+6. **Created: `test/project_test.sh`**
+   - Comprehensive test script for all project endpoints
+
+## Notes
+
+- Project IDs are generated using the format `proj-{uuid}` where uuid is a shortened UUID (22 characters)
+- The mock server stores all data in memory - data is lost when the server restarts
+- All operations are thread-safe using `sync.Map` under the hood
+- Error responses follow the standard format with `code` and `message` fields
+- Success responses follow the format with `code: 0` and `data` field

--- a/mock-server/main.go
+++ b/mock-server/main.go
@@ -20,7 +20,13 @@ func main() {
 	// Define the API endpoint
 	v2 := r.Group("/v2")
 	{
-		v2.GET("/projects", byoc_project.GetProjects)
+		// Standard project endpoints
+		v2.POST("/projects", byoc_project.CreateProject)
+		v2.GET("/projects", byoc_project.ListProjects)
+		v2.GET("/projects/:projectId", byoc_project.GetProjectById)
+		v2.PATCH("/projects/:projectId/plan", byoc_project.UpgradeProjectPlan)
+		v2.DELETE("/projects/:projectId", byoc_project.DeleteProject)
+
 		clusters := v2.Group("/clusters")
 		{
 			clusters.POST("/createDedicated", byoc_project.CreateDedicatedCluster)

--- a/mock-server/pkg/byoc_project/cluster.go
+++ b/mock-server/pkg/byoc_project/cluster.go
@@ -32,11 +32,11 @@ func CreateDedicatedCluster(c *gin.Context) {
 	connectAddress := fmt.Sprintf("https://%s.%s.vectordb-uat3.zillizcloud.com:19540", clusterId, request.RegionId)
 
 	cluster := &DedicatedClusterResponse{
-		ClusterId:          clusterId,
-		ClusterName:        request.ClusterName,
-		ProjectId:          request.ProjectId,
-		Description:        request.Description,
-		RegionId:           func() string {
+		ClusterId:   clusterId,
+		ClusterName: request.ClusterName,
+		ProjectId:   request.ProjectId,
+		Description: request.Description,
+		RegionId: func() string {
 			if request.RegionId == "" {
 				// byoc case, use default region id
 				return "aws-us-west-2"
@@ -76,11 +76,11 @@ func CreateDedicatedCluster(c *gin.Context) {
 	c.JSON(http.StatusOK, Response[*DedicatedClusterResponse]{
 		Code: 0,
 		Data: &DedicatedClusterResponse{
-			ClusterId: clusterId,
+			ClusterId:   clusterId,
 			Description: cluster.Description,
-			Username:  cluster.Username,
-			Password:  cluster.Password,
-			Prompt:    cluster.Prompt,
+			Username:    cluster.Username,
+			Password:    cluster.Password,
+			Prompt:      cluster.Prompt,
 		},
 	})
 }
@@ -154,9 +154,9 @@ func CreateServerlessCluster(c *gin.Context) {
 		Code: 0,
 		Data: &ServerlessClusterResponse{
 			ClusterId: clusterId,
-			Username: cluster.Username,
-			Password: cluster.Password,
-			Prompt: cluster.Prompt,
+			Username:  cluster.Username,
+			Password:  cluster.Password,
+			Prompt:    cluster.Prompt,
 		},
 	})
 }
@@ -230,9 +230,9 @@ func CreateFreeCluster(c *gin.Context) {
 		Code: 0,
 		Data: &FreeClusterResponse{
 			ClusterId: clusterId,
-			Username: cluster.Username,
-			Password: cluster.Password,
-			Prompt: cluster.Prompt,
+			Username:  cluster.Username,
+			Password:  cluster.Password,
+			Prompt:    cluster.Prompt,
 		},
 	})
 }
@@ -343,20 +343,6 @@ func SuspendCluster(c *gin.Context) {
 	})
 }
 
-func GetProjects(c *gin.Context) {
-	projects := projectStore.GetAll()
-
-	projectList := make([]Project, 0, len(projects))
-	for _, p := range projects {
-		projectList = append(projectList, *p)
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"code": 0,
-		"data": projectList,
-	})
-}
-
 func ModifyClusterReplica(c *gin.Context) {
 	clusterId := c.Param("clusterId")
 
@@ -400,8 +386,6 @@ func ModifyClusterReplica(c *gin.Context) {
 		},
 	})
 }
-
-
 
 func GetLabels(c *gin.Context) {
 	clusterId := c.Param("clusterId")
@@ -551,4 +535,3 @@ func UpsertSecurityGroups(c *gin.Context) {
 		},
 	})
 }
-

--- a/mock-server/pkg/byoc_project/model.go
+++ b/mock-server/pkg/byoc_project/model.go
@@ -389,10 +389,20 @@ type DedicatedClusterResponse struct {
 }
 
 type Project struct {
-	ProjectName   string `json:"projectName"`
-	ProjectId     string `json:"projectId"`
-	InstanceCount int    `json:"instanceCount"`
-	CreateTime    string `json:"createTime"`
+	ProjectName     string `json:"projectName"`
+	ProjectId       string `json:"projectId"`
+	InstanceCount   int64  `json:"instanceCount"`
+	CreateTimeMilli int64  `json:"createTimeMilli"`
+	Plan            string `json:"plan"`
+}
+
+type CreateProjectRequest struct {
+	ProjectName string `json:"projectName"`
+	Plan        string `json:"plan"`
+}
+
+type UpgradeProjectPlanRequest struct {
+	Plan string `json:"plan"`
 }
 
 type ModifyReplicaRequest struct {

--- a/mock-server/pkg/byoc_project/project.go
+++ b/mock-server/pkg/byoc_project/project.go
@@ -1,0 +1,177 @@
+package byoc_project
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// CreateProject creates a new standard project
+func CreateProject(c *gin.Context) {
+	var request CreateProjectRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": err.Error(),
+		})
+		return
+	}
+
+	// Validate required fields
+	if request.ProjectName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": "projectName is required",
+		})
+		return
+	}
+
+	if request.Plan == "" {
+		request.Plan = "Enterprise" // Default plan
+	}
+
+	// Generate new project ID
+	projectId := fmt.Sprintf("proj-%s", uuid.New().String()[:22])
+
+	// Create project
+	project := &Project{
+		ProjectName:     request.ProjectName,
+		ProjectId:       projectId,
+		InstanceCount:   0,
+		CreateTimeMilli: time.Now().UnixMilli(),
+		Plan:            request.Plan,
+	}
+
+	// Store project
+	projectStore.Set(projectId, project)
+
+	// Return project ID
+	c.JSON(http.StatusOK, gin.H{
+		"code": 0,
+		"data": projectId,
+	})
+}
+
+// ListProjects returns all projects
+func ListProjects(c *gin.Context) {
+	projects := projectStore.GetAll()
+
+	projectList := make([]Project, 0, len(projects))
+	for _, p := range projects {
+		projectList = append(projectList, *p)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code": 0,
+		"data": projectList,
+	})
+}
+
+// GetProjectById returns a specific project by ID
+func GetProjectById(c *gin.Context) {
+	projectId := c.Param("projectId")
+
+	if projectId == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": "projectId is required",
+		})
+		return
+	}
+
+	project := projectStore.Get(projectId)
+	if project == nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"code":    404,
+			"message": fmt.Sprintf("Project with ID %s not found", projectId),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code": 0,
+		"data": *project,
+	})
+}
+
+// UpgradeProjectPlan upgrades the plan for a project
+func UpgradeProjectPlan(c *gin.Context) {
+	projectId := c.Param("projectId")
+
+	if projectId == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": "projectId is required",
+		})
+		return
+	}
+
+	var request UpgradeProjectPlanRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": err.Error(),
+		})
+		return
+	}
+
+	if request.Plan == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": "plan is required",
+		})
+		return
+	}
+
+	project := projectStore.Get(projectId)
+	if project == nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"code":    404,
+			"message": fmt.Sprintf("Project with ID %s not found", projectId),
+		})
+		return
+	}
+
+	// Update the plan
+	project.Plan = request.Plan
+	projectStore.Set(projectId, project)
+
+	// Return success message
+	c.JSON(http.StatusOK, gin.H{
+		"code": 0,
+		"data": fmt.Sprintf("Project %s plan upgraded to %s", projectId, request.Plan),
+	})
+}
+
+// DeleteProject deletes a project (mock - just returns success)
+func DeleteProject(c *gin.Context) {
+	projectId := c.Param("projectId")
+
+	if projectId == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": "projectId is required",
+		})
+		return
+	}
+
+	project := projectStore.Get(projectId)
+	if project == nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"code":    404,
+			"message": fmt.Sprintf("Project with ID %s not found", projectId),
+		})
+		return
+	}
+
+	// Delete from store
+	projectStore.Delete(projectId)
+
+	c.JSON(http.StatusOK, gin.H{
+		"code": 0,
+		"data": fmt.Sprintf("Project %s deleted successfully", projectId),
+	})
+}

--- a/mock-server/pkg/byoc_project/store.go
+++ b/mock-server/pkg/byoc_project/store.go
@@ -54,10 +54,11 @@ var (
 
 func init() {
 	defaultProject := &Project{
-		ProjectName:   "Default Project",
-		ProjectId:     "proj-ebc5ac7f430702aec8c57b",
-		InstanceCount: 0,
-		CreateTime:    "2023-12-28T07:17:49Z",
+		ProjectName:     "Default Project",
+		ProjectId:       "proj-ebc5ac7f430702aec8c57b",
+		InstanceCount:   0,
+		CreateTimeMilli: 1703745469000, // 2023-12-28T07:17:49Z
+		Plan:            "Enterprise",
 	}
 	projectStore.Set(defaultProject.ProjectId, defaultProject)
 }
@@ -96,4 +97,8 @@ func (s *safeStore[T]) GetAll() []*T {
 		return true
 	})
 	return results
+}
+
+func (s *safeStore[T]) Delete(key string) {
+	s.store.Delete(key)
 }

--- a/mock-server/test/project_test.sh
+++ b/mock-server/test/project_test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Test script for project endpoints
+# Make sure the mock server is running on port 8080
+
+BASE_URL="http://localhost:8080/v2"
+
+echo "========================================="
+echo "Testing Project Endpoints"
+echo "========================================="
+
+# Test 1: List all projects (should have default project)
+echo ""
+echo "1. List all projects:"
+curl -s -X GET "$BASE_URL/projects" | jq .
+
+# Test 2: Create a new project
+echo ""
+echo "2. Create a new project:"
+PROJECT_RESPONSE=$(curl -s -X POST "$BASE_URL/projects" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectName": "test-project-terraform",
+    "plan": "Standard"
+  }')
+echo $PROJECT_RESPONSE | jq .
+
+PROJECT_ID=$(echo $PROJECT_RESPONSE | jq -r '.data')
+echo "Created project ID: $PROJECT_ID"
+
+# Test 3: Get project by ID
+echo ""
+echo "3. Get project by ID:"
+curl -s -X GET "$BASE_URL/projects/$PROJECT_ID" | jq .
+
+# Test 4: List all projects again (should now have 2)
+echo ""
+echo "4. List all projects (should have 2):"
+curl -s -X GET "$BASE_URL/projects" | jq .
+
+# Test 5: Upgrade project plan
+echo ""
+echo "5. Upgrade project plan to Enterprise:"
+curl -s -X PATCH "$BASE_URL/projects/$PROJECT_ID/plan" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "plan": "Enterprise"
+  }' | jq .
+
+# Test 6: Get project by ID to verify upgrade
+echo ""
+echo "6. Get project by ID (verify plan upgraded):"
+curl -s -X GET "$BASE_URL/projects/$PROJECT_ID" | jq .
+
+# Test 7: Create project with default plan
+echo ""
+echo "7. Create project with default plan:"
+DEFAULT_PROJECT_RESPONSE=$(curl -s -X POST "$BASE_URL/projects" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectName": "test-project-default"
+  }')
+echo $DEFAULT_PROJECT_RESPONSE | jq .
+
+DEFAULT_PROJECT_ID=$(echo $DEFAULT_PROJECT_RESPONSE | jq -r '.data')
+echo ""
+echo "8. Get default project (should have Enterprise plan):"
+curl -s -X GET "$BASE_URL/projects/$DEFAULT_PROJECT_ID" | jq .
+
+# Test 9: Delete project
+echo ""
+echo "9. Delete project:"
+curl -s -X DELETE "$BASE_URL/projects/$PROJECT_ID" | jq .
+
+# Test 10: Try to get deleted project (should fail)
+echo ""
+echo "10. Try to get deleted project (should return 404):"
+curl -s -X GET "$BASE_URL/projects/$PROJECT_ID" | jq .
+
+# Test 11: List all projects (should not include deleted project)
+echo ""
+echo "11. List all projects (should not include deleted project):"
+curl -s -X GET "$BASE_URL/projects" | jq .
+
+echo ""
+echo "========================================="
+echo "Project endpoint tests completed!"
+echo "========================================="


### PR DESCRIPTION
This pull request adds comprehensive support for standard project management endpoints to the mock server, closely mirroring the Zilliz Cloud API. It introduces new handlers, updates the project data model, and provides thorough documentation and testing for these endpoints. The changes ensure thread-safe operations, clear error handling, and easy extensibility for future project features.

**Standard Project Endpoints Implementation:**

* Added new handler functions in `project.go` for creating, listing, retrieving, upgrading, and deleting projects, with thread-safe operations using `safeStore`.
* Updated the API routing in `main.go` to use the new standard project endpoints under `/v2/projects`.
* Removed the old `GetProjects()` function from `cluster.go`, consolidating all project-related logic into `project.go`.

**Data Model Enhancements:**

* Extended the `Project` struct in `model.go` to include `Plan` and `CreateTimeMilli` fields, and added request types for project creation and plan upgrade.
* Updated default project initialization in `store.go` to include the new fields and added a `Delete()` method to `safeStore` for project deletion. [[1]](diffhunk://#diff-42f9d3ee7fb4a8413def560f794f1c36d93a63b0e7f3aee268fb57c4addf1dbcL60-R61) [[2]](diffhunk://#diff-42f9d3ee7fb4a8413def560f794f1c36d93a63b0e7f3aee268fb57c4addf1dbcR101-R104)

**Documentation and Testing:**

* Added a detailed documentation file `PROJECT_ENDPOINTS.md` describing all supported project endpoints, request/response formats, and implementation details.
* Created a comprehensive test script `test/project_test.sh` to verify all project endpoint behaviors, including edge cases.