### PR TITLE
refactor: deprecate plan field in cluster resource

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -79,7 +79,7 @@ resource "zillizcloud_cluster" "enterprise_plan_cluster" {
 - `desired_status` (String) The desired status of the cluster. Possible values are RUNNING and SUSPENDED. Defaults to RUNNING.
 - `labels` (Map of String) A map of labels to assign to the cluster. Labels are key-value pairs that can be used to organize and categorize clusters.
 - `load_balancer_security_groups` (Set of String, Deprecated) A set of security group IDs to associate with the load balancer of the cluster.
-- `plan` (String) The plan tier of the Zilliz Cloud service. Available options are Serverless, Standard and Enterprise.
+- `plan` (String, Deprecated) The plan tier of the Zilliz Cloud service. Available options are Serverless, Standard and Enterprise.
 - `region_id` (String) The ID of the region where the cluster exists.
 - `replica` (Number) The number of replicas for the cluster. Defaults to 1.
 - `replica_settings` (Attributes) Query compute unit configuration for the cluster. The cu_settings and cu_size cannot be set simultaneously. (see [below for nested schema](#nestedatt--replica_settings))

--- a/internal/planmodifier/ignore_changes_string.go
+++ b/internal/planmodifier/ignore_changes_string.go
@@ -1,0 +1,38 @@
+package planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// ignoreChangesString implements a PlanModifier that suppresses all diffs
+// for deprecated fields by keeping the prior state value.
+type ignoreChangesString struct{}
+
+func (m ignoreChangesString) Description(ctx context.Context) string {
+	return "Ignore any configuration changes by keeping the prior state value."
+}
+
+func (m ignoreChangesString) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m ignoreChangesString) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// If the resource already exists (state is not null/unknown), keep the state value
+	// This completely suppresses any diff for this field
+	if !req.StateValue.IsNull() && !req.StateValue.IsUnknown() {
+		resp.PlanValue = req.StateValue
+		return
+	}
+
+	// For new resources: use the config value (or null if not set)
+	// This allows the first apply to write a value to state, which is then preserved
+	resp.PlanValue = req.ConfigValue
+}
+
+// IgnoreChangesString returns a PlanModifier that suppresses all diffs
+// by keeping the prior state value. Use this for deprecated fields.
+func IgnoreChangesString() planmodifier.String {
+	return ignoreChangesString{}
+}


### PR DESCRIPTION
## Summary
The plan field has been promoted to the project resource level, making it redundant in the cluster resource. This PR deprecates the plan field in zillizcloud_cluster resource to prepare for its removal in a future major version.
## Changes
Add DeprecationMessage: Users will see a warning when using the plan field
Add IgnoreChangesString PlanModifier: Suppresses all diffs for the deprecated field
Modify Read() to preserve state: Only sets plan from API when state is empty (e.g., import)

Scenario | Behavior
-- | --
---------- | ----------
Existing resources | Modifying plan field produces no diff
New resources | Initial plan value is fetched from API
terraform refresh | State value is preserved, no drift
Using plan in HCL | Shows deprecation warning
