### PR TITLE
fix(cluster): sync cu_settings and replica_settings from API on Read

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -233,6 +233,11 @@ type Cluster struct {
 			Max       *int             `json:"max,omitempty"`
 			Schedules []ScheduleConfig `json:"schedules,omitempty"`
 		} `json:"cu"`
+		Replica struct {
+			Min       *int             `json:"min,omitempty"`
+			Max       *int             `json:"max,omitempty"`
+			Schedules []ScheduleConfig `json:"schedules,omitempty"`
+		} `json:"replica"`
 	} `json:"autoscaling"`
 }
 

--- a/internal/cluster/autoscaling_drift_test.go
+++ b/internal/cluster/autoscaling_drift_test.go
@@ -1,0 +1,300 @@
+package cluster_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	provider "github.com/zilliztech/terraform-provider-zillizcloud/internal/provider"
+)
+
+// simulateConsoleAutoscaling calls the Zilliz Cloud API directly to simulate
+// a user configuring cu autoscaling via the console (outside of Terraform).
+func simulateConsoleAutoscaling(clusterID string, cuMin, cuMax int) error {
+	host := os.Getenv("ZILLIZCLOUD_HOST_ADDRESS")
+	if host == "" {
+		host = "https://api.cloud.zilliz.com/v2"
+	}
+	apiKey := os.Getenv("ZILLIZCLOUD_API_KEY")
+
+	body := fmt.Sprintf(`{"autoscaling":{"cu":{"min":%d,"max":%d}}}`, cuMin, cuMax)
+	req, err := http.NewRequest("POST", host+"/clusters/"+clusterID+"/modify", bytes.NewBufferString(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var result struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return fmt.Errorf("failed to parse API response: %w", err)
+	}
+	if result.Code != 0 {
+		return fmt.Errorf("API error code %d: %s", result.Code, result.Message)
+	}
+	return nil
+}
+
+// extractClusterID is a Check helper that captures the cluster ID for use in PreConfig.
+func extractClusterID(resourceName string, dst *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found", resourceName)
+		}
+		*dst = rs.Primary.ID
+		return nil
+	}
+}
+
+// TestAccReadSyncsCuSettingsFromConsole verifies that when autoscaling is
+// configured via the console (API) on a cluster that was created without
+// cu_settings, Read() populates cu_settings from the API so that adding
+// a matching cu_settings block in HCL results in no diff.
+func TestAccReadSyncsCuSettingsFromConsole(t *testing.T) {
+	t.Parallel()
+	var clusterID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create cluster without cu_settings
+			{
+				Config: provider.ProviderConfig + `
+data "zillizcloud_project" "default" {
+}
+
+resource "zillizcloud_cluster" "test" {
+  cluster_name = "drift-console-add"
+  region_id    = "aws-us-west-2"
+  plan         = "Enterprise"
+  cu_type      = "Performance-optimized"
+  cu_size      = 2
+  project_id   = data.zillizcloud_project.default.id
+  timeouts {
+    create = "120m"
+    update = "120m"
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "status", "RUNNING"),
+					extractClusterID("zillizcloud_cluster.test", &clusterID),
+				),
+			},
+			// Step 2: Console configures autoscaling, HCL adds matching cu_settings.
+			// After fix, Read syncs from API → state matches HCL → apply is no-op.
+			{
+				PreConfig: func() {
+					if err := simulateConsoleAutoscaling(clusterID, 2, 4); err != nil {
+						t.Fatalf("failed to simulate console autoscaling: %v", err)
+					}
+				},
+				Config: provider.ProviderConfig + `
+data "zillizcloud_project" "default" {
+}
+
+resource "zillizcloud_cluster" "test" {
+  cluster_name = "drift-console-add"
+  region_id    = "aws-us-west-2"
+  plan         = "Enterprise"
+  cu_type      = "Performance-optimized"
+  project_id   = data.zillizcloud_project.default.id
+  cu_settings = {
+    dynamic_scaling = {
+      min = 2
+      max = 4
+    }
+  }
+  timeouts {
+    create = "120m"
+    update = "120m"
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "status", "RUNNING"),
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cu_settings.dynamic_scaling.min", "2"),
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cu_settings.dynamic_scaling.max", "4"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccReadDetectsCuSettingsDrift verifies that when autoscaling is changed
+// via the console after Terraform configured it, Read() detects the drift and
+// the next apply reverts to the HCL-specified values.
+func TestAccReadDetectsCuSettingsDrift(t *testing.T) {
+	t.Parallel()
+	var clusterID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with cu_settings { min=2, max=4 }
+			{
+				Config: provider.ProviderConfig + `
+data "zillizcloud_project" "default" {
+}
+
+resource "zillizcloud_cluster" "test" {
+  cluster_name = "drift-console-change"
+  region_id    = "aws-us-west-2"
+  plan         = "Enterprise"
+  cu_type      = "Performance-optimized"
+  project_id   = data.zillizcloud_project.default.id
+  cu_settings = {
+    dynamic_scaling = {
+      min = 2
+      max = 4
+    }
+  }
+  timeouts {
+    create = "120m"
+    update = "120m"
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "status", "RUNNING"),
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cu_settings.dynamic_scaling.min", "2"),
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cu_settings.dynamic_scaling.max", "4"),
+					extractClusterID("zillizcloud_cluster.test", &clusterID),
+				),
+			},
+			// Step 2: Console changes autoscaling to { min=4, max=8 }.
+			// Same HCL { min=2, max=4 } → Read detects drift → apply reverts.
+			{
+				PreConfig: func() {
+					if err := simulateConsoleAutoscaling(clusterID, 4, 8); err != nil {
+						t.Fatalf("failed to simulate console autoscaling change: %v", err)
+					}
+				},
+				Config: provider.ProviderConfig + `
+data "zillizcloud_project" "default" {
+}
+
+resource "zillizcloud_cluster" "test" {
+  cluster_name = "drift-console-change"
+  region_id    = "aws-us-west-2"
+  plan         = "Enterprise"
+  cu_type      = "Performance-optimized"
+  project_id   = data.zillizcloud_project.default.id
+  cu_settings = {
+    dynamic_scaling = {
+      min = 2
+      max = 4
+    }
+  }
+  timeouts {
+    create = "120m"
+    update = "120m"
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "status", "RUNNING"),
+					// After apply, values should be reverted to HCL values
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cu_settings.dynamic_scaling.min", "2"),
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cu_settings.dynamic_scaling.max", "4"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccReadDetectsCuSettingsDriftThenUserUpdatesHCL verifies the scenario
+// where autoscaling is changed via console, and then the user updates their
+// HCL to a different (third) value. The apply should set the HCL value.
+func TestAccReadDetectsCuSettingsDriftThenUserUpdatesHCL(t *testing.T) {
+	t.Parallel()
+	var clusterID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with cu_settings { min=2, max=4 }
+			{
+				Config: provider.ProviderConfig + `
+data "zillizcloud_project" "default" {
+}
+
+resource "zillizcloud_cluster" "test" {
+  cluster_name = "drift-user-update"
+  region_id    = "aws-us-west-2"
+  plan         = "Enterprise"
+  cu_type      = "Performance-optimized"
+  project_id   = data.zillizcloud_project.default.id
+  cu_settings = {
+    dynamic_scaling = {
+      min = 2
+      max = 4
+    }
+  }
+  timeouts {
+    create = "120m"
+    update = "120m"
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "status", "RUNNING"),
+					extractClusterID("zillizcloud_cluster.test", &clusterID),
+				),
+			},
+			// Step 2: Console changes to { min=4, max=8 }, user updates HCL to { min=2, max=8 }.
+			{
+				PreConfig: func() {
+					if err := simulateConsoleAutoscaling(clusterID, 4, 8); err != nil {
+						t.Fatalf("failed to simulate console autoscaling change: %v", err)
+					}
+				},
+				Config: provider.ProviderConfig + `
+data "zillizcloud_project" "default" {
+}
+
+resource "zillizcloud_cluster" "test" {
+  cluster_name = "drift-user-update"
+  region_id    = "aws-us-west-2"
+  plan         = "Enterprise"
+  cu_type      = "Performance-optimized"
+  project_id   = data.zillizcloud_project.default.id
+  cu_settings = {
+    dynamic_scaling = {
+      min = 2
+      max = 8
+    }
+  }
+  timeouts {
+    create = "120m"
+    update = "120m"
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "status", "RUNNING"),
+					// Should reflect the user's HCL values, not the console values
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cu_settings.dynamic_scaling.min", "2"),
+					resource.TestCheckResourceAttr("zillizcloud_cluster.test", "cu_settings.dynamic_scaling.max", "8"),
+				),
+			},
+		},
+	})
+}

--- a/internal/cluster/cluster_resource.go
+++ b/internal/cluster/cluster_resource.go
@@ -557,6 +557,16 @@ func (r *ClusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 	state.CuSize = cluster.CuSize
 	state.CuType = cluster.CuType
 
+	// Sync autoscaling settings from API so drift detection is accurate.
+	// Only update when the API reports actual settings, so users without
+	// autoscaling don't see phantom diffs.
+	if cluster.CuSettings != nil {
+		state.CuSettings = cluster.CuSettings
+	}
+	if cluster.ReplicaSettings != nil {
+		state.ReplicaSettings = cluster.ReplicaSettings
+	}
+
 	if state.DesiredStatus.IsNull() {
 		state.DesiredStatus = cluster.Status
 	}

--- a/internal/cluster/cluster_resource.go
+++ b/internal/cluster/cluster_resource.go
@@ -557,15 +557,11 @@ func (r *ClusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 	state.CuSize = cluster.CuSize
 	state.CuType = cluster.CuType
 
-	// Sync autoscaling settings from API so drift detection is accurate.
-	// Only update when the API reports actual settings, so users without
-	// autoscaling don't see phantom diffs.
-	if cluster.CuSettings != nil {
-		state.CuSettings = cluster.CuSettings
-	}
-	if cluster.ReplicaSettings != nil {
-		state.ReplicaSettings = cluster.ReplicaSettings
-	}
+	// Sync autoscaling settings from API unconditionally so drift detection
+	// works in all directions: console adds, console changes, console removes.
+	// store.Get returns nil when the cluster has no autoscaling configured.
+	state.CuSettings = cluster.CuSettings
+	state.ReplicaSettings = cluster.ReplicaSettings
 
 	if state.DesiredStatus.IsNull() {
 		state.DesiredStatus = cluster.Status

--- a/internal/cluster/store.go
+++ b/internal/cluster/store.go
@@ -38,22 +38,57 @@ func (c *ClusterStoreImpl) Get(ctx context.Context, clusterId string) (*ClusterR
 		return nil, err
 	}
 
-	var dynamicScaling *DynamicScaling
+	// Parse CU autoscaling
+	var cuDynamic *DynamicScaling
 	if cluster.Autoscaling.CU.Min != nil && cluster.Autoscaling.CU.Max != nil {
-		dynamicScaling = &DynamicScaling{
+		cuDynamic = &DynamicScaling{
 			Min: types.Int64Value(int64(*cluster.Autoscaling.CU.Min)),
 			Max: types.Int64Value(int64(*cluster.Autoscaling.CU.Max)),
 		}
 	}
-
-	var schedules []ScheduleScaling
+	var cuSchedules []ScheduleScaling
 	if len(cluster.Autoscaling.CU.Schedules) > 0 {
-		schedules = make([]ScheduleScaling, len(cluster.Autoscaling.CU.Schedules))
+		cuSchedules = make([]ScheduleScaling, len(cluster.Autoscaling.CU.Schedules))
 		for i, s := range cluster.Autoscaling.CU.Schedules {
-			schedules[i] = ScheduleScaling{
-				Cron:   types.StringValue(s.Cron),
-				Target: types.Int64Value(int64(s.Target)),
+			cuSchedules[i] = ScheduleScaling{
+				Timezone: types.StringValue(s.Timezone),
+				Cron:     types.StringValue(s.Cron),
+				Target:   types.Int64Value(int64(s.Target)),
 			}
+		}
+	}
+	var cuSettings *CuSettings
+	if cuDynamic != nil || len(cuSchedules) > 0 {
+		cuSettings = &CuSettings{
+			DynamicScaling:  cuDynamic,
+			ScheduleScaling: cuSchedules,
+		}
+	}
+
+	// Parse Replica autoscaling
+	var replicaDynamic *DynamicScaling
+	if cluster.Autoscaling.Replica.Min != nil && cluster.Autoscaling.Replica.Max != nil {
+		replicaDynamic = &DynamicScaling{
+			Min: types.Int64Value(int64(*cluster.Autoscaling.Replica.Min)),
+			Max: types.Int64Value(int64(*cluster.Autoscaling.Replica.Max)),
+		}
+	}
+	var replicaSchedules []ScheduleScaling
+	if len(cluster.Autoscaling.Replica.Schedules) > 0 {
+		replicaSchedules = make([]ScheduleScaling, len(cluster.Autoscaling.Replica.Schedules))
+		for i, s := range cluster.Autoscaling.Replica.Schedules {
+			replicaSchedules[i] = ScheduleScaling{
+				Timezone: types.StringValue(s.Timezone),
+				Cron:     types.StringValue(s.Cron),
+				Target:   types.Int64Value(int64(s.Target)),
+			}
+		}
+	}
+	var replicaSettings *ReplicaSettings
+	if replicaDynamic != nil || len(replicaSchedules) > 0 {
+		replicaSettings = &ReplicaSettings{
+			DynamicScaling:  replicaDynamic,
+			ScheduleScaling: replicaSchedules,
 		}
 	}
 
@@ -92,11 +127,9 @@ func (c *ClusterStoreImpl) Get(ctx context.Context, clusterId string) (*ClusterR
 			}
 			return cluster.Replica
 		}()),
-		AwsCseKeyArn: types.StringValue(cluster.AwsCseKeyArn),
-		CuSettings: &CuSettings{
-			DynamicScaling:  dynamicScaling,
-			ScheduleScaling: schedules,
-		},
+		AwsCseKeyArn:    types.StringValue(cluster.AwsCseKeyArn),
+		CuSettings:      cuSettings,
+		ReplicaSettings: replicaSettings,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
Supersedes #206 with a more complete fix.

- `Read()` now copies `CuSettings` and `ReplicaSettings` from `DescribeCluster` response into state, eliminating phantom diffs on plan when autoscaling is already configured on the live cluster
- `store.Get()` now populates `ReplicaSettings` from `cluster.Autoscaling.Replica` (was missing entirely)
- `store.Get()` now includes `Timezone` in `ScheduleScaling` round-trip
- `store.Get()` returns `nil` for `CuSettings`/`ReplicaSettings` when both `DynamicScaling` and `ScheduleScaling` are empty, preventing spurious empty blocks for clusters without autoscaling
- `client.Cluster` struct now includes `Autoscaling.Replica` field to deserialize replica autoscaling from the API

## Test plan
- [ ] Existing unit tests pass
- [ ] Verify on production: cluster with cu_settings configured shows clean plan (no phantom diff)
- [ ] Verify cluster without autoscaling shows no spurious cu_settings block

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)