### PR TITLE
fix: api_key cluster_ids null & user 401 on fresh cluster

### DIFF
--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -21,6 +21,7 @@ var _ resource.Resource = &ApiKeyResource{}
 var _ resource.ResourceWithConfigure = &ApiKeyResource{}
 var _ resource.ResourceWithImportState = &ApiKeyResource{}
 var _ resource.ResourceWithValidateConfig = &ApiKeyResource{}
+var _ resource.ResourceWithModifyPlan = &ApiKeyResource{}
 
 func NewApiKeyResource() resource.Resource {
 	return &ApiKeyResource{}
@@ -153,6 +154,38 @@ func (r *ApiKeyResource) ValidateConfig(ctx context.Context, req resource.Valida
 			"Missing project_access",
 			`At least one "project_access" entry is required when role is "Member".`,
 		)
+	}
+}
+
+func (r *ApiKeyResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Destroy — nothing to do.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan ApiKeyResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// When cluster_ids is provided, all_cluster must be false. Auto-correct
+	// the plan so users don't have to specify both explicitly.
+	modified := false
+	for i := range plan.ProjectAccess {
+		if plan.ProjectAccess[i].ClusterIds.IsNull() || plan.ProjectAccess[i].ClusterIds.IsUnknown() {
+			continue
+		}
+		var ids []string
+		resp.Diagnostics.Append(plan.ProjectAccess[i].ClusterIds.ElementsAs(ctx, &ids, false)...)
+		if len(ids) > 0 && plan.ProjectAccess[i].AllCluster.ValueBool() {
+			plan.ProjectAccess[i].AllCluster = types.BoolValue(false)
+			modified = true
+		}
+	}
+
+	if modified {
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
 	}
 }
 

--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -155,6 +155,20 @@ func (r *ApiKeyResource) ValidateConfig(ctx context.Context, req resource.Valida
 			`At least one "project_access" entry is required when role is "Member".`,
 		)
 	}
+
+	for _, pa := range data.ProjectAccess {
+		// In config phase, all_cluster is null when user omitted it (Default
+		// hasn't been applied yet). A non-null true means user explicitly
+		// wrote all_cluster = true, which conflicts with cluster_ids.
+		if !pa.AllCluster.IsNull() && pa.AllCluster.ValueBool() && !pa.ClusterIds.IsNull() {
+			resp.Diagnostics.AddError(
+				"Conflicting configuration",
+				`Cannot set all_cluster = true and cluster_ids at the same time. `+
+					`Either remove all_cluster (or set it to false) when using cluster_ids, `+
+					`or remove cluster_ids when using all_cluster = true.`,
+			)
+		}
+	}
 }
 
 func (r *ApiKeyResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {

--- a/internal/provider/apikey_resource_test.go
+++ b/internal/provider/apikey_resource_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 const testProjectId = "proj-dee71c5a02aee5d781b156"
+const testClusterId = "in01-85c9ae8df55f5cd" // Zilliz-Gclust-02, used for cluster_ids tests
 
 func TestAccApiKeyResource_Member(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -137,6 +138,87 @@ resource "zillizcloud_api_key" "readonly" {
 `, testProjectId),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("zillizcloud_api_key.readonly", "project_access.0.role", "Read-Write"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccApiKeyResource_ClusterIdsInferAllClusterFalse verifies that when
+// cluster_ids is set without explicitly setting all_cluster = false,
+// ModifyPlan automatically sets all_cluster to false and the apply succeeds.
+func TestAccApiKeyResource_ClusterIdsInferAllClusterFalse(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: cluster_ids without all_cluster — should auto-infer false
+			{
+				Config: provider.ProviderConfig + fmt.Sprintf(`
+resource "zillizcloud_api_key" "cluster_ids_test" {
+  name = "tf-acc-test-clusterids"
+  role = "Member"
+
+  project_access = [{
+    project_id  = %q
+    role        = "Read-Only"
+    cluster_ids = [%q]
+  }]
+}
+`, testProjectId, testClusterId),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("zillizcloud_api_key.cluster_ids_test", "id"),
+					resource.TestCheckResourceAttr("zillizcloud_api_key.cluster_ids_test", "project_access.0.all_cluster", "false"),
+					resource.TestCheckResourceAttr("zillizcloud_api_key.cluster_ids_test", "project_access.0.cluster_ids.#", "1"),
+					resource.TestCheckResourceAttr("zillizcloud_api_key.cluster_ids_test", "project_access.0.cluster_ids.0", testClusterId),
+				),
+			},
+			// Step 2: same config, re-apply should be no-op
+			{
+				Config: provider.ProviderConfig + fmt.Sprintf(`
+resource "zillizcloud_api_key" "cluster_ids_test" {
+  name = "tf-acc-test-clusterids"
+  role = "Member"
+
+  project_access = [{
+    project_id  = %q
+    role        = "Read-Only"
+    cluster_ids = [%q]
+  }]
+}
+`, testProjectId, testClusterId),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("zillizcloud_api_key.cluster_ids_test", "project_access.0.all_cluster", "false"),
+					resource.TestCheckResourceAttr("zillizcloud_api_key.cluster_ids_test", "project_access.0.cluster_ids.0", testClusterId),
+				),
+			},
+		},
+	})
+}
+
+// TestAccApiKeyResource_ClusterIdsExplicitAllClusterFalse verifies backward
+// compatibility: explicitly setting all_cluster = false with cluster_ids works.
+func TestAccApiKeyResource_ClusterIdsExplicitAllClusterFalse(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: provider.ProviderConfig + fmt.Sprintf(`
+resource "zillizcloud_api_key" "explicit_test" {
+  name = "tf-acc-test-explicit-ac"
+  role = "Member"
+
+  project_access = [{
+    project_id  = %q
+    role        = "Read-Only"
+    all_cluster = false
+    cluster_ids = [%q]
+  }]
+}
+`, testProjectId, testClusterId),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("zillizcloud_api_key.explicit_test", "id"),
+					resource.TestCheckResourceAttr("zillizcloud_api_key.explicit_test", "project_access.0.all_cluster", "false"),
+					resource.TestCheckResourceAttr("zillizcloud_api_key.explicit_test", "project_access.0.cluster_ids.0", testClusterId),
 				),
 			},
 		},

--- a/internal/provider/apikey_resource_test.go
+++ b/internal/provider/apikey_resource_test.go
@@ -99,6 +99,30 @@ resource "zillizcloud_api_key" "bad" {
 	})
 }
 
+func TestAccApiKeyResource_AllClusterTrueWithClusterIdsConflict(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: provider.ProviderConfig + fmt.Sprintf(`
+resource "zillizcloud_api_key" "conflict" {
+  name = "tf-acc-test-conflict"
+  role = "Member"
+
+  project_access = [{
+    project_id  = %q
+    role        = "Read-Only"
+    all_cluster = true
+    cluster_ids = [%q]
+  }]
+}
+`, testProjectId, testClusterId),
+				ExpectError: regexp.MustCompile(`Conflicting configuration`),
+			},
+		},
+	})
+}
+
 func TestAccApiKeyResource_ProjectRoles(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	zilliz "github.com/zilliztech/terraform-provider-zillizcloud/client"
 )
 
@@ -136,14 +138,43 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	err = client.CreateUser(&zilliz.CreateUserParams{
-		Username: data.Username.ValueString(),
-		Password: data.Password.ValueString(),
-	})
-	if err != nil {
+	// Retry creating the user — freshly created clusters may return 401
+	// while the vectordb endpoint initializes its auth system.
+	// Exponential backoff: 2s, 4s, 8s, 16s, 30s, 30s, ... (cap 30s, ~2min total)
+	var createErr error
+	backoff := 2 * time.Second
+	const maxBackoff = 30 * time.Second
+	const maxAttempts = 8
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		createErr = client.CreateUser(&zilliz.CreateUserParams{
+			Username: data.Username.ValueString(),
+			Password: data.Password.ValueString(),
+		})
+		if createErr == nil {
+			break
+		}
+		if !isRetryableClusterError(createErr) || attempt == maxAttempts {
+			break
+		}
+		tflog.Info(ctx, fmt.Sprintf("Cluster endpoint not ready, retrying in %s (attempt %d/%d)...", backoff, attempt, maxAttempts))
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError(
+				"Timed out creating user",
+				fmt.Sprintf("ConnectAddress: %s, Username: %s, error: %s", data.ConnectAddress.ValueString(), data.Username.ValueString(), createErr.Error()),
+			)
+			return
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+	if createErr != nil {
 		resp.Diagnostics.AddError(
 			"Failed to create user",
-			fmt.Sprintf("ConnectAddress: %s, Username: %s, error: %s", data.ConnectAddress.ValueString(), data.Username.ValueString(), err.Error()),
+			fmt.Sprintf("ConnectAddress: %s, Username: %s, error: %s", data.ConnectAddress.ValueString(), data.Username.ValueString(), createErr.Error()),
 		)
 		return
 	}
@@ -335,4 +366,17 @@ func ParseUserID(id string) (string, string, bool) {
 		return "", "", false
 	}
 	return parts[2], parts[4], true
+}
+
+// isRetryableClusterError returns true for transient errors that occur when a
+// freshly created cluster's vectordb endpoint is not yet fully initialized.
+func isRetryableClusterError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "status code: 401") ||
+		strings.Contains(msg, "status code: 503") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "no such host")
 }

--- a/internal/provider/user_resource_retry_test.go
+++ b/internal/provider/user_resource_retry_test.go
@@ -1,0 +1,64 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsRetryableClusterError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{
+			name:      "nil error",
+			err:       nil,
+			retryable: false,
+		},
+		{
+			name:      "401 auth not ready",
+			err:       fmt.Errorf("http status code: 401, error: user hasn't authenticated"),
+			retryable: true,
+		},
+		{
+			name:      "503 service unavailable",
+			err:       fmt.Errorf("http status code: 503, error: service unavailable"),
+			retryable: true,
+		},
+		{
+			name:      "connection refused",
+			err:       fmt.Errorf("dial tcp 10.0.0.1:19539: connection refused"),
+			retryable: true,
+		},
+		{
+			name:      "dns not ready",
+			err:       fmt.Errorf("dial tcp: lookup in01-xxx.vectordb.zillizcloud.com: no such host"),
+			retryable: true,
+		},
+		{
+			name:      "400 bad request - not retryable",
+			err:       fmt.Errorf("http status code: 400, error: invalid parameter"),
+			retryable: false,
+		},
+		{
+			name:      "user already exists - not retryable",
+			err:       fmt.Errorf("Error[65535]:user already exists"),
+			retryable: false,
+		},
+		{
+			name:      "permission denied - not retryable",
+			err:       fmt.Errorf("http status code: 403, error: permission denied"),
+			retryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryableClusterError(tt.err)
+			if got != tt.retryable {
+				t.Errorf("isRetryableClusterError(%v) = %v, want %v", tt.err, got, tt.retryable)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two reported issues on v0.6.32:

- **api_key: `cluster_ids` returns null after apply** — When `cluster_ids` is set without explicitly setting `all_cluster = false`, the schema default (`true`) causes the API to ignore the cluster IDs. The GET response then returns empty clusters, and the provider writes `cluster_ids = null` to state, triggering "Provider produced inconsistent result after apply". Fix: add `ModifyPlan` to auto-infer `all_cluster = false` when `cluster_ids` is provided.

- **user: 401 on freshly created cluster** — When `zillizcloud_cluster` and `zillizcloud_user` are created in the same apply, the cluster's vectordb endpoint may not be ready for auth operations immediately after reporting RUNNING status. Fix: add exponential backoff retry (2s → 4s → 8s → 16s → 30s, ~2min total) for transient 401/503/connection errors.

## Test plan

- [x] Reproduced api_key issue on production with v0.6.32 (cluster_ids without all_cluster=false)
- [x] Verified fix with dev_overrides: apply succeeds, re-plan shows no diff
- [x] Added acceptance tests: `TestAccApiKeyResource_ClusterIdsInferAllClusterFalse`, `TestAccApiKeyResource_ClusterIdsExplicitAllClusterFalse`
- [x] Added unit tests for `isRetryableClusterError` (8 cases)
- [x] `go build ./...` and `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)