### PR TITLE
docs: add PrivateLink Terraform examples

### DIFF
--- a/examples/data-sources/zillizcloud_endpoint_services/data-source.tf
+++ b/examples/data-sources/zillizcloud_endpoint_services/data-source.tf
@@ -1,0 +1,7 @@
+data "zillizcloud_endpoint_services" "this" {
+  region_id = "aws-us-west-2"
+}
+
+output "available_services" {
+  value = data.zillizcloud_endpoint_services.this.endpoint_services[0].endpoint_service
+}

--- a/examples/data-sources/zillizcloud_endpoints/data-source.tf
+++ b/examples/data-sources/zillizcloud_endpoints/data-source.tf
@@ -1,0 +1,7 @@
+data "zillizcloud_endpoints" "mine" {
+  project_id = "proj-xxxxxxxxxxxxxxxxxxxxxxxx"
+}
+
+output "endpoints" {
+  value = data.zillizcloud_endpoints.mine.endpoints
+}

--- a/examples/resources/zillizcloud_endpoint/resource.tf
+++ b/examples/resources/zillizcloud_endpoint/resource.tf
@@ -1,0 +1,13 @@
+resource "zillizcloud_endpoint" "aws" {
+  project_id  = "proj-xxxxxxxxxxxxxxxxxxxxxxxx"
+  region_id   = "aws-us-west-2"
+  endpoint_id = "vpce-072eaf2b4a747c24f"
+}
+
+# GCP example — gcp_project_id is required
+resource "zillizcloud_endpoint" "gcp" {
+  project_id     = "proj-xxxxxxxxxxxxxxxxxxxxxxxx"
+  region_id      = "gcp-us-west1"
+  endpoint_id    = "my-psc-endpoint"
+  gcp_project_id = "my-gcp-project"
+}

--- a/examples/resources/zillizcloud_endpoint_whitelist/resource.tf
+++ b/examples/resources/zillizcloud_endpoint_whitelist/resource.tf
@@ -1,0 +1,7 @@
+# NOTE: Destroy is a no-op - the whitelist entry is not removed from Zilliz Cloud
+# on `terraform destroy`. Manual cleanup via console or support is required.
+resource "zillizcloud_endpoint_whitelist" "azure" {
+  project_id    = "proj-xxxxxxxxxxxxxxxxxxxxxxxx"
+  region_id     = "azure-eastus2"
+  outer_user_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}


### PR DESCRIPTION
## Summary

Adds runnable example configurations for the new PrivateLink resources and data sources introduced in #211.

### What's included

- `examples/resources/zillizcloud_endpoint/resource.tf` — example usage of the `zillizcloud_endpoint` resource (AWS and GCP variants).
- `examples/resources/zillizcloud_endpoint_whitelist/resource.tf` — example usage of the `zillizcloud_endpoint_whitelist` resource.
- `examples/data-sources/zillizcloud_endpoint_services/data-source.tf` — example usage of the `zillizcloud_endpoint_services` data source.
- `examples/data-sources/zillizcloud_endpoints/data-source.tf` — example usage of the `zillizcloud_endpoints` data source.

### Stack

This is **PR 2 of 3** in the PrivateLink feature stack.
- Previous: #211 — Core client, provider resources and data sources
- Next: #3 — Guides and generated documentation