### PR TITLE
fix(provider): expose project region ids

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+        with:
+          terraform_version: '1.8.0-alpha20240216'
+          terraform_wrapper: false
       - run: go mod download
       - name: Wait for mock server to be ready
         run: |

--- a/client/project.go
+++ b/client/project.go
@@ -1,11 +1,12 @@
 package client
 
 type Project struct {
-	ProjectId       string `json:"projectId"`
-	ProjectName     string `json:"projectName"`
-	CreateTimeMilli int64  `json:"createTimeMilli"`
-	InstanceCount   int64  `json:"instanceCount"`
-	Plan            string `json:"plan"`
+	ProjectId       string   `json:"projectId"`
+	ProjectName     string   `json:"projectName"`
+	CreateTimeMilli int64    `json:"createTimeMilli"`
+	InstanceCount   int64    `json:"instanceCount"`
+	Plan            string   `json:"plan"`
+	RegionIds       []string `json:"regionIds"`
 }
 
 type CreateProjectRequest struct {

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -44,6 +45,23 @@ func TestClient_ListProject(t *testing.T) {
 		}
 	})
 
+}
+
+func TestProject_UnmarshalRegionFields(t *testing.T) {
+	var response zillizResponse[[]Project]
+	err := json.Unmarshal([]byte(`{"code":0,"data":[{"projectId":"proj-001","projectName":"test-project","instanceCount":0,"createTimeMilli":1762324757000,"plan":"Enterprise","regionIds":["aws-us-east-1","gcp-us-west1"]}]}`), &response)
+	if err != nil {
+		t.Fatalf("failed to unmarshal project response: %v", err)
+	}
+
+	if len(response.Data) != 1 {
+		t.Fatalf("want 1 project, got %d", len(response.Data))
+	}
+
+	project := response.Data[0]
+	if len(project.RegionIds) != 2 || project.RegionIds[0] != "aws-us-east-1" || project.RegionIds[1] != "gcp-us-west1" {
+		t.Fatalf("unexpected region ids: %v", project.RegionIds)
+	}
 }
 
 func TestClient_CreateProject(t *testing.T) {

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -24,3 +24,4 @@ description: |-
 
 - `created_at` (Number) Created At
 - `instance_count` (Number) Instance Count
+- `region_ids` (List of String) Region IDs bound to the project

--- a/internal/provider/projects_data_source.go
+++ b/internal/provider/projects_data_source.go
@@ -33,6 +33,7 @@ type ProjectsDataSourceModel struct {
 	Name          types.String `tfsdk:"name"`
 	InstanceCount types.Int64  `tfsdk:"instance_count"`
 	CreatedAt     types.Int64  `tfsdk:"created_at"`
+	RegionIds     types.List   `tfsdk:"region_ids"`
 }
 
 func (d *ProjectDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -58,6 +59,11 @@ func (d *ProjectDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			"created_at": schema.Int64Attribute{
 				MarkdownDescription: "Created At",
 				Computed:            true,
+			},
+			"region_ids": schema.ListAttribute{
+				MarkdownDescription: "Region IDs bound to the project",
+				Computed:            true,
+				ElementType:         types.StringType,
 			},
 		},
 	}
@@ -140,9 +146,15 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	state.Name = types.StringValue(p.ProjectName)
 	state.InstanceCount = types.Int64Value(p.InstanceCount)
 	state.CreatedAt = types.Int64Value(p.CreateTimeMilli)
+	regionIds, diags := types.ListValueFrom(ctx, types.StringType, p.RegionIds)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.RegionIds = regionIds
 
 	// Set state
-	diags := resp.State.Set(ctx, &state)
+	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/utils/conv.go
+++ b/internal/provider/utils/conv.go
@@ -71,7 +71,7 @@ func SliceToMap(input any) (map[string]any, error) {
 		item := v.Index(i)
 
 		// Dereference pointer if needed
-		if item.Kind() == reflect.Ptr {
+		if item.Kind() == reflect.Pointer {
 			item = item.Elem()
 		}
 


### PR DESCRIPTION
## Summary
- add `regionIds` to the project API client model
- expose computed `region_ids` on the `zillizcloud_project` data source
- update project data source docs and API response decoding coverage
- install Terraform CLI in the mock-server test workflow so provider tests do not depend on hc-install downloading Terraform during CI
- use `reflect.Pointer` in the reflection helper to satisfy current `go vet`

## Verification
- `go test ./...`

## Notes
- `go generate ./...` was previously attempted locally but could not run because `terraform` is not installed in PATH on this machine; the CI generate job installs Terraform itself.