### PR TITLE
fix(cluster): avoid fixed replica drift with autoscaling

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -117,7 +117,7 @@ resource "zillizcloud_cluster" "full_autoscaling_cluster" {
 - `load_balancer_security_groups` (Set of String, Deprecated) A set of security group IDs to associate with the load balancer of the cluster.
 - `plan` (String) The plan tier of the Zilliz Cloud service. Available options are Serverless, Standard and Enterprise.
 - `region_id` (String) The ID of the region where the cluster exists.
-- `replica` (Number) The number of replicas for the cluster. Defaults to 1.
+- `replica` (Number) The number of replicas for the cluster. If omitted, the API default/current value is used.
 - `replica_settings` (Attributes) Query CU replica scaling configuration for the cluster. The replica_settings and replica cannot be set simultaneously. (see [below for nested schema](#nestedatt--replica_settings))
 - `status` (String) The current status of the cluster. Possible values are RUNNING, SUSPENDING, SUSPENDED, and RESUMING.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/internal/cluster/cluster_resource.go
+++ b/internal/cluster/cluster_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -42,9 +41,11 @@ const (
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
-var _ resource.Resource = &ClusterResource{}
-var _ resource.ResourceWithConfigure = &ClusterResource{}
-var _ resource.ResourceWithImportState = &ClusterResource{}
+var (
+	_ resource.Resource                = &ClusterResource{}
+	_ resource.ResourceWithConfigure   = &ClusterResource{}
+	_ resource.ResourceWithImportState = &ClusterResource{}
+)
 
 func NewClusterResource() resource.Resource {
 	return &ClusterResource{}
@@ -206,10 +207,12 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 			"replica": schema.Int64Attribute{
-				MarkdownDescription: "The number of replicas for the cluster. Defaults to 1.",
+				MarkdownDescription: "The number of replicas for the cluster. If omitted, the API default/current value is used.",
 				Optional:            true,
 				Computed:            true,
-				Default:             int64default.StaticInt64(1),
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 					customvalidator.ReplicaCuSizeValidator{},
@@ -385,7 +388,7 @@ func (r *ClusterResource) Configure(ctx context.Context, req resource.ConfigureR
 }
 
 func CloneClient(ctx context.Context, client *zilliz.Client, data *ClusterResourceModel) (*zilliz.Client, error) {
-	var regionId = client.RegionId
+	regionId := client.RegionId
 
 	if data.RegionId.ValueString() != "" {
 		regionId = data.RegionId.ValueString()
@@ -430,7 +433,7 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 
 	// If cu_settings.dynamic_scaling is configured but cu_size is not explicitly set,
 	// use the min value as the initial cu_size so the cluster starts at the correct size.
-	if tfPlan.CuSettings != nil && !tfPlan.CuSettings.IsdynamicScalingNull() &&
+	if tfPlan.CuSettings != nil && !tfPlan.CuSettings.IsDynamicScalingNull() &&
 		(tfPlan.CuSize.IsNull() || tfPlan.CuSize.IsUnknown()) {
 		tfPlan.CuSize = tfPlan.CuSettings.DynamicScaling.Min
 	}
@@ -454,6 +457,7 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 	} else {
 		tfState.CuSize = types.Int64Value(1)
 	}
+	tfState.completeReplicaAfterCreate(tfPlan)
 	tfState.Plan = types.StringValue("unknown")
 
 	// Apply cu_settings and/or replica_settings immediately after creation (API does not require RUNNING state).
@@ -483,6 +487,9 @@ func (r *ClusterResource) tryBestUpdateStatesAfterCreation(ctx context.Context, 
 		state.Description = newState.Description
 		state.RegionId = newState.RegionId
 		state.Plan = newState.Plan
+		if plan.Replica.IsNull() || plan.Replica.IsUnknown() {
+			state.Replica = newState.Replica
+		}
 	}
 
 	// Apply replica > 1 after cluster is RUNNING (ModifyReplica API requires RUNNING state and sufficient cuSize).
@@ -492,6 +499,7 @@ func (r *ClusterResource) tryBestUpdateStatesAfterCreation(ctx context.Context, 
 		if err != nil {
 			resp.Diagnostics.AddWarning("Failed to modify cluster replica", err.Error())
 		} else {
+			state.Replica = plan.Replica
 			// Wait for RUNNING after replica change, using the remaining create context timeout
 			if deadline, ok := ctx.Deadline(); ok {
 				remaining := time.Until(deadline)
@@ -698,17 +706,17 @@ func (r *ClusterResource) handleAutoscalingUpdate(ctx context.Context, plan, sta
 	ptrInt := func(v int64) *int { i := int(v); return &i }
 
 	// Validate: dynamic_scaling and schedule_scaling are mutually exclusive within each settings block
-	if plan.CuSettings != nil && !plan.CuSettings.IsdynamicScalingNull() && !plan.CuSettings.IsSchedulesNull() {
+	if plan.CuSettings != nil && !plan.CuSettings.IsDynamicScalingNull() && !plan.CuSettings.IsSchedulesNull() {
 		diags.AddError("Invalid configuration", "cu_settings: cannot set both dynamic_scaling and schedule_scaling at the same time")
 		return diags
 	}
-	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsdynamicScalingNull() && !plan.ReplicaSettings.IsSchedulesNull() {
+	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsDynamicScalingNull() && !plan.ReplicaSettings.IsSchedulesNull() {
 		diags.AddError("Invalid configuration", "replica_settings: cannot set both dynamic_scaling and schedule_scaling at the same time")
 		return diags
 	}
 
 	// Validate min <= max
-	if plan.CuSettings != nil && !plan.CuSettings.IsdynamicScalingNull() {
+	if plan.CuSettings != nil && !plan.CuSettings.IsDynamicScalingNull() {
 		if plan.CuSettings.DynamicScaling.Min.ValueInt64() > plan.CuSettings.DynamicScaling.Max.ValueInt64() {
 			diags.AddError("Invalid autoscaling configuration", fmt.Sprintf(
 				"cu_settings: min (%d) must be <= max (%d)",
@@ -716,7 +724,7 @@ func (r *ClusterResource) handleAutoscalingUpdate(ctx context.Context, plan, sta
 			return diags
 		}
 	}
-	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsdynamicScalingNull() {
+	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsDynamicScalingNull() {
 		if plan.ReplicaSettings.DynamicScaling.Min.ValueInt64() > plan.ReplicaSettings.DynamicScaling.Max.ValueInt64() {
 			diags.AddError("Invalid autoscaling configuration", fmt.Sprintf(
 				"replica_settings: min (%d) must be <= max (%d)",
@@ -728,7 +736,7 @@ func (r *ClusterResource) handleAutoscalingUpdate(ctx context.Context, plan, sta
 	// Build the combined payload
 	params := &zilliz.ModifyAutoscalingCombinedParams{}
 
-	if plan.CuSettings != nil && !plan.CuSettings.IsdynamicScalingNull() {
+	if plan.CuSettings != nil && !plan.CuSettings.IsDynamicScalingNull() {
 		params.Autoscaling.CU.Min = ptrInt(plan.CuSettings.DynamicScaling.Min.ValueInt64())
 		params.Autoscaling.CU.Max = ptrInt(plan.CuSettings.DynamicScaling.Max.ValueInt64())
 	}
@@ -740,7 +748,7 @@ func (r *ClusterResource) handleAutoscalingUpdate(ctx context.Context, plan, sta
 		params.Autoscaling.CU.Schedules = &schedules
 	}
 
-	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsdynamicScalingNull() {
+	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsDynamicScalingNull() {
 		params.Autoscaling.Replica.Min = ptrInt(plan.ReplicaSettings.DynamicScaling.Min.ValueInt64())
 		params.Autoscaling.Replica.Max = ptrInt(plan.ReplicaSettings.DynamicScaling.Max.ValueInt64())
 	}
@@ -786,20 +794,23 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// Validate that cu_size and replica are not changed at the same time
-	if plan.isCuSizeChanged(state) && plan.isReplicaChanged(state) {
+	cuSizeChanged := plan.isCuSizeChanged(state) && plan.isCuSettingsDisabled()
+	replicaChanged := plan.isReplicaChanged(state) && plan.isReplicaSettingsDisabled()
+
+	// Validate that fixed cu_size and fixed replica are not changed at the same time
+	if cuSizeChanged && replicaChanged {
 		resp.Diagnostics.AddError("Invalid configuration change", "Cannot change cu_size and replica at the same time. Please update them in separate operations.")
 		return
 	}
 
-	if plan.isCuSizeChanged(state) && plan.isCuSettingsDisabled() {
+	if cuSizeChanged {
 		resp.Diagnostics.Append(r.handleCuSizeUpdate(ctx, plan, state)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 	}
 
-	if plan.isReplicaChanged(state) && plan.isReplicaSettingsDisabled() {
+	if replicaChanged {
 		resp.Diagnostics.Append(r.handleReplicaUpdate(ctx, plan, state)...)
 		if resp.Diagnostics.HasError() {
 			return

--- a/internal/cluster/model.go
+++ b/internal/cluster/model.go
@@ -49,7 +49,7 @@ func (c *ReplicaSettings) Equal(other *ReplicaSettings) bool {
 	return c.DynamicScaling.Equal(other.DynamicScaling) && SchedulesEqual(c.ScheduleScaling, other.ScheduleScaling)
 }
 
-func (c *CuSettings) IsdynamicScalingNull() bool {
+func (c *CuSettings) IsDynamicScalingNull() bool {
 	return c.DynamicScaling == nil || c.DynamicScaling.Min.IsNull() || c.DynamicScaling.Max.IsNull()
 }
 
@@ -57,7 +57,7 @@ func (c *CuSettings) IsSchedulesNull() bool {
 	return c == nil || len(c.ScheduleScaling) == 0
 }
 
-func (c *ReplicaSettings) IsdynamicScalingNull() bool {
+func (c *ReplicaSettings) IsDynamicScalingNull() bool {
 	return c.DynamicScaling == nil || c.DynamicScaling.Min.IsNull() || c.DynamicScaling.Max.IsNull()
 }
 
@@ -146,11 +146,17 @@ func (b *BucketInfo) Equal(other *BucketInfo) bool {
 }
 
 func (c *ClusterResourceModel) isCuSettingsDisabled() bool {
-	return c.CuSettings == nil || c.CuSettings.DynamicScaling == nil || c.CuSettings.ScheduleScaling == nil
+	return c.CuSettings == nil || (c.CuSettings.IsDynamicScalingNull() && c.CuSettings.IsSchedulesNull())
 }
 
 func (c *ClusterResourceModel) isReplicaSettingsDisabled() bool {
-	return c.ReplicaSettings == nil || c.ReplicaSettings.DynamicScaling == nil || c.ReplicaSettings.ScheduleScaling == nil
+	return c.ReplicaSettings == nil || (c.ReplicaSettings.IsDynamicScalingNull() && c.ReplicaSettings.IsSchedulesNull())
+}
+
+func (c *ClusterResourceModel) completeReplicaAfterCreate(plan ClusterResourceModel) {
+	if plan.Replica.IsNull() || plan.Replica.IsUnknown() {
+		c.Replica = types.Int64Value(1)
+	}
 }
 
 func (c *ClusterResourceModel) setUnknown() {
@@ -169,7 +175,6 @@ func (c *ClusterResourceModel) setUnknown() {
 
 // populate the ClusterResourceModel with the input which is the response from the API.
 func (c *ClusterResourceModel) populate(input *ClusterResourceModel) {
-
 	c.ClusterId = input.ClusterId
 	c.ClusterName = input.ClusterName
 	c.ProjectId = input.ProjectId
@@ -195,7 +200,6 @@ func (c *ClusterResourceModel) populate(input *ClusterResourceModel) {
 		c.CuType = types.StringValue("Performance-optimized")
 		c.Replica = types.Int64Value(1)
 	}
-
 }
 
 // only for free or serverless plan, set default value

--- a/internal/cluster/model_autoscaling_test.go
+++ b/internal/cluster/model_autoscaling_test.go
@@ -1,0 +1,169 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSettingsDisabledRecognizesAutoscalingModes(t *testing.T) {
+	dynamic := &DynamicScaling{
+		Min: types.Int64Value(1),
+		Max: types.Int64Value(3),
+	}
+	schedules := []ScheduleScaling{
+		{
+			Timezone: types.StringValue("UTC"),
+			Cron:     types.StringValue("0 0 * * *"),
+			Target:   types.Int64Value(2),
+		},
+	}
+
+	tests := []struct {
+		name            string
+		model           ClusterResourceModel
+		cuDisabled      bool
+		replicaDisabled bool
+	}{
+		{
+			name:            "nil settings",
+			model:           ClusterResourceModel{},
+			cuDisabled:      true,
+			replicaDisabled: true,
+		},
+		{
+			name: "dynamic settings",
+			model: ClusterResourceModel{
+				CuSettings:      &CuSettings{DynamicScaling: dynamic},
+				ReplicaSettings: &ReplicaSettings{DynamicScaling: dynamic},
+			},
+			cuDisabled:      false,
+			replicaDisabled: false,
+		},
+		{
+			name: "schedule settings",
+			model: ClusterResourceModel{
+				CuSettings:      &CuSettings{ScheduleScaling: schedules},
+				ReplicaSettings: &ReplicaSettings{ScheduleScaling: schedules},
+			},
+			cuDisabled:      false,
+			replicaDisabled: false,
+		},
+		{
+			name: "empty settings",
+			model: ClusterResourceModel{
+				CuSettings:      &CuSettings{},
+				ReplicaSettings: &ReplicaSettings{},
+			},
+			cuDisabled:      true,
+			replicaDisabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.model.isCuSettingsDisabled(); got != tt.cuDisabled {
+				t.Fatalf("isCuSettingsDisabled() = %v, want %v", got, tt.cuDisabled)
+			}
+			if got := tt.model.isReplicaSettingsDisabled(); got != tt.replicaDisabled {
+				t.Fatalf("isReplicaSettingsDisabled() = %v, want %v", got, tt.replicaDisabled)
+			}
+		})
+	}
+}
+
+func TestAutoscalingRuntimeDriftDoesNotRequireFixedScaleUpdate(t *testing.T) {
+	replicaSettings := &ReplicaSettings{
+		DynamicScaling: &DynamicScaling{
+			Min: types.Int64Value(1),
+			Max: types.Int64Value(3),
+		},
+	}
+	cuSettings := &CuSettings{
+		DynamicScaling: &DynamicScaling{
+			Min: types.Int64Value(2),
+			Max: types.Int64Value(8),
+		},
+	}
+
+	plan := ClusterResourceModel{
+		CuSize:          types.Int64Value(2),
+		Replica:         types.Int64Value(1),
+		CuSettings:      cuSettings,
+		ReplicaSettings: replicaSettings,
+	}
+	state := ClusterResourceModel{
+		CuSize:          types.Int64Value(6),
+		Replica:         types.Int64Value(3),
+		CuSettings:      cuSettings,
+		ReplicaSettings: replicaSettings,
+	}
+
+	if !plan.isCuSizeChanged(state) {
+		t.Fatal("expected runtime cu_size drift to differ from the fixed plan value")
+	}
+	if !plan.isReplicaChanged(state) {
+		t.Fatal("expected runtime replica drift to differ from the fixed plan value")
+	}
+
+	cuSizeChanged := plan.isCuSizeChanged(state) && plan.isCuSettingsDisabled()
+	replicaChanged := plan.isReplicaChanged(state) && plan.isReplicaSettingsDisabled()
+	if cuSizeChanged {
+		t.Fatal("dynamic cu_settings should prevent fixed cu_size update")
+	}
+	if replicaChanged {
+		t.Fatal("dynamic replica_settings should prevent fixed replica update")
+	}
+}
+
+func TestReplicaSchemaUsesStateForUnknownWithoutDefault(t *testing.T) {
+	var resp resource.SchemaResponse
+	NewClusterResource().Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	attr, ok := resp.Schema.Attributes["replica"].(schema.Int64Attribute)
+	if !ok {
+		t.Fatalf("replica attribute type = %T, want schema.Int64Attribute", resp.Schema.Attributes["replica"])
+	}
+	if attr.Default != nil {
+		t.Fatal("replica should not inject a default value")
+	}
+	if len(attr.PlanModifiers) == 0 {
+		t.Fatal("replica should keep prior state when the planned value is unknown")
+	}
+}
+
+func TestCompleteReplicaAfterCreateFillsOmittedReplica(t *testing.T) {
+	state := ClusterResourceModel{
+		Replica: types.Int64Unknown(),
+	}
+	plan := ClusterResourceModel{
+		Replica: types.Int64Unknown(),
+	}
+
+	state.completeReplicaAfterCreate(plan)
+
+	if state.Replica.IsUnknown() || state.Replica.IsNull() {
+		t.Fatal("replica should be known after create")
+	}
+	if got := state.Replica.ValueInt64(); got != 1 {
+		t.Fatalf("replica = %d, want 1", got)
+	}
+}
+
+func TestCompleteReplicaAfterCreateKeepsConfiguredReplica(t *testing.T) {
+	state := ClusterResourceModel{
+		Replica: types.Int64Value(2),
+	}
+	plan := ClusterResourceModel{
+		Replica: types.Int64Value(2),
+	}
+
+	state.completeReplicaAfterCreate(plan)
+
+	if got := state.Replica.ValueInt64(); got != 2 {
+		t.Fatalf("replica = %d, want 2", got)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -64,6 +64,9 @@ _terralist-verify:
 plan dir:
   terraform -chdir={{dir}} plan
 
+refresh dir:
+  terraform -chdir={{dir}} refresh
+
 apply dir:
   terraform -chdir={{dir}} apply -auto-approve
 
@@ -93,3 +96,5 @@ fmt:
 mock-server:
 	cd mock-server && go run main.go
 
+
+prepare: fmt lint doc


### PR DESCRIPTION
Remove the default value from the cluster replica attribute and rely on UseStateForUnknown so omitted replica configuration does not get planned as a fixed replica count.

Fix autoscaling-enabled detection for CU and replica settings so dynamic-only or schedule-only settings are not treated as disabled. This prevents runtime autoscaling changes from triggering fixed cu_size or replica updates.

Ensure create always writes a known replica value when replica is omitted, avoiding unknown state after apply.