### PR TITLE
feat(provider): set and propagate provider version in User-Agent header

### DIFF
--- a/client/zilliz.go
+++ b/client/zilliz.go
@@ -235,7 +235,7 @@ func WithDefaultClient() Option {
 func WithDefaultUserAgent() Option {
 	return func(c *Client) {
 		if c.userAgent == "" {
-			c.userAgent = "zilliztech/terraform-provider-zillizcloud"
+			c.userAgent = "terraform-provider-zillizcloud/dev"
 		}
 	}
 }
@@ -318,7 +318,7 @@ func (c *Client) newRequest(method string, u *url.URL, body interface{}) (*http.
 	if err != nil {
 		return nil, err
 	}
-	// req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Set("Accept", "application/json")
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")

--- a/client/zilliz_test.go
+++ b/client/zilliz_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"net/url"
 	"testing"
 )
 
@@ -77,4 +78,48 @@ func TestNewClient(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientNewRequestSetsDefaultUserAgent(t *testing.T) {
+	c, err := NewClient(WithApiKey("gibberish_key"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	req, err := c.newRequest("GET", mustParseURL(t, "https://api.test/v2/projects"), nil)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+
+	if got, want := req.Header.Get("User-Agent"), "terraform-provider-zillizcloud/dev"; got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestClientNewRequestSetsCustomUserAgent(t *testing.T) {
+	c, err := NewClient(
+		WithApiKey("gibberish_key"),
+		WithUserAgent("terraform-provider-zillizcloud/0.6.36"),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	req, err := c.newRequest("GET", mustParseURL(t, "https://api.test/v2/projects"), nil)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+
+	if got, want := req.Header.Get("User-Agent"), "terraform-provider-zillizcloud/0.6.36"; got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	return u
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -91,6 +92,7 @@ func (p *ZillizProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		zilliz.WithApiKey(config.apiKey),
 		zilliz.WithCloudRegionId(data.RegionId.ValueString()),
 		zilliz.WithHostAddress(config.hostAddress),
+		zilliz.WithUserAgent(providerUserAgent(p.version)),
 		zilliz.WithRateLimiter(config.qps, config.burst),
 	)
 	if err != nil {
@@ -107,6 +109,13 @@ type clientConfig struct {
 	hostAddress string
 	qps         float64
 	burst       int64
+}
+
+func providerUserAgent(version string) string {
+	if version == "" {
+		version = "dev"
+	}
+	return fmt.Sprintf("terraform-provider-zillizcloud/%s", version)
 }
 
 func (p *ZillizProvider) buildClientConfig(data zillizProviderModel, resp *provider.ConfigureResponse) clientConfig {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,29 @@
+package provider
+
+import "testing"
+
+func TestProviderUserAgent(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "release version",
+			version: "0.6.36",
+			want:    "terraform-provider-zillizcloud/0.6.36",
+		},
+		{
+			name: "empty version defaults to dev",
+			want: "terraform-provider-zillizcloud/dev",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := providerUserAgent(tc.version); got != tc.want {
+				t.Fatalf("providerUserAgent(%q) = %q, want %q", tc.version, got, tc.want)
+			}
+		})
+	}
+}

--- a/scripts/terralist/build-platform.sh
+++ b/scripts/terralist/build-platform.sh
@@ -12,6 +12,7 @@ terralist_parse_platform "$PUBLISH_PLATFORM"
 
 PACKAGE="${PACKAGE:-.}"
 CGO_ENABLED="${CGO_ENABLED:-0}"
+GO_LDFLAGS="${GO_LDFLAGS:--s -w -X main.version=${PUBLISH_VERSION#v}}"
 terralist_init_paths --create-dist
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/terralist-provider-build.XXXXXX")"
@@ -22,11 +23,11 @@ zip_name="$(terralist_zip_name "$GOOS_VALUE" "$GOARCH_VALUE")"
 build_dir="$tmp_dir/${GOOS_VALUE}_${GOARCH_VALUE}"
 mkdir -p "$build_dir"
 
-terralist_log "terralist-build" "go build ${GOOS_VALUE}/${GOARCH_VALUE}"
+terralist_log "terralist-build" "go build ${GOOS_VALUE}/${GOARCH_VALUE} version=${PUBLISH_VERSION#v}"
 (
   cd "$SOURCE_DIR"
   CGO_ENABLED="$CGO_ENABLED" GOOS="$GOOS_VALUE" GOARCH="$GOARCH_VALUE" \
-    go build -buildvcs=false -o "$build_dir/$binary_name" "$PACKAGE"
+    go build -buildvcs=false -ldflags "$GO_LDFLAGS" -o "$build_dir/$binary_name" "$PACKAGE"
 )
 chmod 755 "$build_dir/$binary_name"
 


### PR DESCRIPTION
- Configure the HTTP client to send User-Agent as "`terraform-provider-zillizcloud/<version>`".
- Fix client request setup to correctly set the User-Agent header using the configured value.
- Pass the build version to the provider binary via ldflags in the build script.
- Add unit tests to verify the User-Agent formatting and request header injection behavior.