### PR TITLE
Support replica and CU autoscaling on cluster create

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -79,23 +79,11 @@ type ScheduleConfig struct {
 
 // modify cluster cu size
 type ModifyClusterAutoscalingParams struct {
-	Autoscaling struct {
-		CU struct {
-			Min       *int              `json:"min,omitempty"`
-			Max       *int              `json:"max,omitempty"`
-			Schedules *[]ScheduleConfig `json:"schedules,omitempty"`
-		} `json:"cu"`
-	} `json:"autoscaling"`
+	Autoscaling AutoscalingConfig `json:"autoscaling"`
 }
 
 type ModifyReplicaSettings struct {
-	Autoscaling struct {
-		Replica struct {
-			Min       *int              `json:"min,omitempty"`
-			Max       *int              `json:"max,omitempty"`
-			Schedules *[]ScheduleConfig `json:"schedules,omitempty"`
-		} `json:"replica"`
-	} `json:"autoscaling"`
+	Autoscaling AutoscalingConfig `json:"autoscaling"`
 }
 
 func (c *Client) ModifyReplicaSettings(clusterId string, params *ModifyReplicaSettings) (*string, error) {
@@ -110,18 +98,7 @@ func (c *Client) ModifyReplicaSettings(clusterId string, params *ModifyReplicaSe
 // ModifyAutoscalingCombinedParams sends both cu and replica autoscaling in a single request
 // to avoid the later call overwriting the earlier one.
 type ModifyAutoscalingCombinedParams struct {
-	Autoscaling struct {
-		CU struct {
-			Min       *int              `json:"min,omitempty"`
-			Max       *int              `json:"max,omitempty"`
-			Schedules *[]ScheduleConfig `json:"schedules,omitempty"`
-		} `json:"cu"`
-		Replica struct {
-			Min       *int              `json:"min,omitempty"`
-			Max       *int              `json:"max,omitempty"`
-			Schedules *[]ScheduleConfig `json:"schedules,omitempty"`
-		} `json:"replica"`
-	} `json:"autoscaling"`
+	Autoscaling AutoscalingConfig `json:"autoscaling"`
 }
 
 func (c *Client) ModifyAutoscalingCombined(clusterId string, params *ModifyAutoscalingCombinedParams) (*string, error) {
@@ -227,23 +204,18 @@ type Cluster struct {
 	Labels             map[string]string `json:"labels,omitempty"`
 	Replica            int64             `json:"replica,omitempty"`
 	AwsCseKeyArn       string            `json:"keyIdentifier,omitempty"`
-	Autoscaling        struct {
-		CU struct {
-			Min       *int             `json:"min,omitempty"`
-			Max       *int             `json:"max,omitempty"`
-			Schedules []ScheduleConfig `json:"schedules,omitempty"`
-		} `json:"cu"`
-		Replica struct {
-			Min       *int             `json:"min,omitempty"`
-			Max       *int             `json:"max,omitempty"`
-			Schedules []ScheduleConfig `json:"schedules,omitempty"`
-		} `json:"replica"`
-	} `json:"autoscaling"`
+	Autoscaling        AutoscalingConfig `json:"autoscaling"`
 }
 
-type Autoscaling struct {
-	Min int `json:"min"`
-	Max int `json:"max"`
+type AutoscalingPolicy struct {
+	Min       *int             `json:"min,omitempty"`
+	Max       *int             `json:"max,omitempty"`
+	Schedules []ScheduleConfig `json:"schedules,omitempty"`
+}
+
+type AutoscalingConfig struct {
+	CU      *AutoscalingPolicy `json:"cu,omitempty"`
+	Replica *AutoscalingPolicy `json:"replica,omitempty"`
 }
 
 func (c *Client) ListClusters() (Clusters, error) {
@@ -280,15 +252,17 @@ func (c *Client) DescribeCluster(clusterId string) (Cluster, error) {
 }
 
 type CreateClusterParams struct {
-	Plan         *string           `json:"plan,omitempty"`
-	ClusterName  string            `json:"clusterName"`
-	CUSize       int               `json:"cuSize"`
-	CUType       string            `json:"cuType"`
-	ProjectId    string            `json:"projectId"`
-	RegionId     string            `json:"regionId"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	BucketInfo   *BucketInfo       `json:"bucketInfo,omitempty"`
-	AwsCseKeyArn *string           `json:"keyIdentifier,omitempty"`
+	Plan         *string            `json:"plan,omitempty"`
+	ClusterName  string             `json:"clusterName"`
+	CUSize       *int               `json:"cuSize,omitempty"`
+	CUType       string             `json:"cuType"`
+	ProjectId    string             `json:"projectId"`
+	RegionId     string             `json:"regionId"`
+	Replica      *int               `json:"replica,omitempty"`
+	Autoscaling  *AutoscalingConfig `json:"autoscaling,omitempty"`
+	Labels       map[string]string  `json:"labels,omitempty"`
+	BucketInfo   *BucketInfo        `json:"bucketInfo,omitempty"`
+	AwsCseKeyArn *string            `json:"keyIdentifier,omitempty"`
 }
 type BucketInfo struct {
 	BucketName string  `json:"bucketName"`

--- a/client/cluster_test.go
+++ b/client/cluster_test.go
@@ -222,8 +222,14 @@ func TestCreateClusterParamsAutoscalingJSON(t *testing.T) {
 	if got["replica"] != float64(2) {
 		t.Fatalf("replica = %v, want 2", got["replica"])
 	}
-	autoscaling := got["autoscaling"].(map[string]any)
-	cu := autoscaling["cu"].(map[string]any)
+	autoscaling, ok := got["autoscaling"].(map[string]any)
+	if !ok {
+		t.Fatalf("autoscaling = %T, want map[string]any", got["autoscaling"])
+	}
+	cu, ok := autoscaling["cu"].(map[string]any)
+	if !ok {
+		t.Fatalf("autoscaling.cu = %T, want map[string]any", autoscaling["cu"])
+	}
 	if cu["min"] != float64(4) || cu["max"] != float64(8) {
 		t.Fatalf("autoscaling.cu = %v, want min=4 max=8", cu)
 	}

--- a/client/cluster_test.go
+++ b/client/cluster_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -54,11 +55,12 @@ func TestClient_Cluster(t *testing.T) {
 	}
 
 	projectID = getProject()
+	cuSize := 1
 	params := CreateClusterParams{
 		ProjectId:   projectID,
 		Plan:        conv.StringPtr("Standard"),
 		ClusterName: "a-standard-type-cluster",
-		CUSize:      1,
+		CUSize:      &cuSize,
 		CUType:      "Performance-optimized",
 		RegionId:    "gcp-us-west1",
 	}
@@ -156,6 +158,78 @@ func TestClient_Cluster(t *testing.T) {
 			t.Fatalf("want = %s, got = %v", clusterId, got)
 		}
 	})
+}
+
+func TestCreateClusterParamsFixedCUJSON(t *testing.T) {
+	cuSize := 4
+	params := CreateClusterParams{
+		ProjectId:   "proj",
+		Plan:        conv.StringPtr("Enterprise"),
+		ClusterName: "fixed-cu",
+		CUSize:      &cuSize,
+		CUType:      "Performance-optimized",
+		RegionId:    "aws-us-west-2",
+	}
+
+	payload, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("unmarshal params: %v", err)
+	}
+	if got["cuSize"] != float64(4) {
+		t.Fatalf("cuSize = %v, want 4", got["cuSize"])
+	}
+	if _, ok := got["autoscaling"]; ok {
+		t.Fatalf("autoscaling should be omitted for fixed CU payload: %s", string(payload))
+	}
+}
+
+func TestCreateClusterParamsAutoscalingJSON(t *testing.T) {
+	minCU := 4
+	maxCU := 8
+	replica := 2
+	params := CreateClusterParams{
+		ProjectId:   "proj",
+		Plan:        conv.StringPtr("Enterprise"),
+		ClusterName: "dynamic-cu",
+		CUType:      "Performance-optimized",
+		RegionId:    "aws-us-west-2",
+		Replica:     &replica,
+		Autoscaling: &AutoscalingConfig{
+			CU: &AutoscalingPolicy{
+				Min: &minCU,
+				Max: &maxCU,
+			},
+		},
+	}
+
+	payload, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("unmarshal params: %v", err)
+	}
+	if _, ok := got["cuSize"]; ok {
+		t.Fatalf("cuSize should be omitted for autoscaling payload: %s", string(payload))
+	}
+	if got["replica"] != float64(2) {
+		t.Fatalf("replica = %v, want 2", got["replica"])
+	}
+	autoscaling := got["autoscaling"].(map[string]any)
+	cu := autoscaling["cu"].(map[string]any)
+	if cu["min"] != float64(4) || cu["max"] != float64(8) {
+		t.Fatalf("autoscaling.cu = %v, want min=4 max=8", cu)
+	}
+	if _, ok := autoscaling["replica"]; ok {
+		t.Fatalf("autoscaling.replica should be omitted for create payload: %s", string(payload))
+	}
 }
 
 func TestClient_ServerlessCluster(t *testing.T) {

--- a/internal/cluster/autoscaling_create_test.go
+++ b/internal/cluster/autoscaling_create_test.go
@@ -51,8 +51,7 @@ resource "zillizcloud_cluster" "test" {
 }
 
 // TestAccReplicaOnCreate verifies that replica > 1 can be set during creation.
-// The provider creates the cluster, waits for RUNNING, then calls ModifyReplica.
-// Requires cu_size >= 12 for multi-replica.
+// Requires Enterprise+ plan and enough CU for multi-replica.
 func TestAccReplicaOnCreate(t *testing.T) {
 	t.Parallel()
 	resource.Test(t, resource.TestCase{

--- a/internal/cluster/cluster_resource.go
+++ b/internal/cluster/cluster_resource.go
@@ -413,6 +413,88 @@ func convertTerraformMapToStringMap(terraformMap types.Map) map[string]string {
 	return labels
 }
 
+func shouldConfigureAutoscalingAfterCreate(plan ClusterResourceModel) bool {
+	if plan.CuSettings != nil && !plan.CuSettings.IsSchedulesNull() {
+		return true
+	}
+	if plan.ReplicaSettings == nil {
+		return false
+	}
+	return !plan.ReplicaSettings.IsDynamicScalingNull() || !plan.ReplicaSettings.IsSchedulesNull()
+}
+
+func validateAutoscalingSettings(plan ClusterResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	validateDynamicScaling := func(name string, settings *DynamicScaling) bool {
+		if settings == nil {
+			return true
+		}
+		minKnown := !settings.Min.IsNull() && !settings.Min.IsUnknown()
+		maxKnown := !settings.Max.IsNull() && !settings.Max.IsUnknown()
+		if minKnown != maxKnown {
+			diags.AddError("Invalid autoscaling configuration", fmt.Sprintf("%s: dynamic_scaling requires both min and max.", name))
+			return false
+		}
+		if minKnown && settings.Min.ValueInt64() > settings.Max.ValueInt64() {
+			diags.AddError("Invalid autoscaling configuration", fmt.Sprintf(
+				"%s: min (%d) must be <= max (%d)",
+				name, settings.Min.ValueInt64(), settings.Max.ValueInt64()))
+			return false
+		}
+		return true
+	}
+
+	if plan.CuSettings != nil && !plan.CuSettings.IsDynamicScalingNull() && !plan.CuSettings.IsSchedulesNull() {
+		diags.AddError("Invalid configuration", "cu_settings: cannot set both dynamic_scaling and schedule_scaling at the same time")
+		return diags
+	}
+	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsDynamicScalingNull() && !plan.ReplicaSettings.IsSchedulesNull() {
+		diags.AddError("Invalid configuration", "replica_settings: cannot set both dynamic_scaling and schedule_scaling at the same time")
+		return diags
+	}
+
+	if plan.CuSettings != nil && !validateDynamicScaling("cu_settings", plan.CuSettings.DynamicScaling) {
+		return diags
+	}
+	if plan.ReplicaSettings != nil && !validateDynamicScaling("replica_settings", plan.ReplicaSettings.DynamicScaling) {
+		return diags
+	}
+
+	return diags
+}
+
+func validateReplicaPlan(plan ClusterResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if plan.Plan.IsNull() || plan.Plan.IsUnknown() {
+		return diags
+	}
+
+	planValue := plan.Plan.ValueString()
+	if planValue == EnterprisePlan || planValue == BusinessCriticalPlan {
+		return diags
+	}
+
+	if !plan.Replica.IsNull() && !plan.Replica.IsUnknown() && plan.Replica.ValueInt64() > 1 {
+		diags.AddError("Invalid replica configuration", "replica greater than 1 requires Enterprise or BusinessCritical plan.")
+		return diags
+	}
+	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsDynamicScalingNull() &&
+		plan.ReplicaSettings.DynamicScaling.Max.ValueInt64() > 1 {
+		diags.AddError("Invalid replica autoscaling configuration", "replica_settings with max greater than 1 requires Enterprise or BusinessCritical plan.")
+		return diags
+	}
+	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsSchedulesNull() {
+		for _, schedule := range plan.ReplicaSettings.ScheduleScaling {
+			if !schedule.Target.IsNull() && !schedule.Target.IsUnknown() && schedule.Target.ValueInt64() > 1 {
+				diags.AddError("Invalid replica autoscaling configuration", "replica_settings schedule target greater than 1 requires Enterprise or BusinessCritical plan.")
+				return diags
+			}
+		}
+	}
+
+	return diags
+}
+
 func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	tflog.Info(ctx, "Create Cluster...")
 	tfPlan := ClusterResourceModel{}
@@ -428,6 +510,11 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 	diags = req.Plan.Get(ctx, &tfPlan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(validateAutoscalingSettings(tfPlan)...)
+	resp.Diagnostics.Append(validateReplicaPlan(tfPlan)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -460,8 +547,8 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 	tfState.completeReplicaAfterCreate(tfPlan)
 	tfState.Plan = types.StringValue("unknown")
 
-	// Apply cu_settings and/or replica_settings immediately after creation (API does not require RUNNING state).
-	if tfPlan.CuSettings != nil || tfPlan.ReplicaSettings != nil {
+	// Apply settings not supported by the create API, such as schedules or replica autoscaling.
+	if shouldConfigureAutoscalingAfterCreate(tfPlan) {
 		asDiags := r.handleAutoscalingUpdate(ctx, tfPlan, tfState)
 		for _, d := range asDiags.Errors() {
 			resp.Diagnostics.AddWarning(d.Summary(), d.Detail())
@@ -489,24 +576,6 @@ func (r *ClusterResource) tryBestUpdateStatesAfterCreation(ctx context.Context, 
 		state.Plan = newState.Plan
 		if plan.Replica.IsNull() || plan.Replica.IsUnknown() {
 			state.Replica = newState.Replica
-		}
-	}
-
-	// Apply replica > 1 after cluster is RUNNING (ModifyReplica API requires RUNNING state and sufficient cuSize).
-	// Note: cannot use handleReplicaUpdate here because r.timeout is only set in Update, not Create.
-	if isRunning && !plan.Replica.IsNull() && !plan.Replica.IsUnknown() && plan.Replica.ValueInt64() > 1 {
-		err := r.store.ModifyReplica(ctx, state.ClusterId.ValueString(), int(plan.Replica.ValueInt64()))
-		if err != nil {
-			resp.Diagnostics.AddWarning("Failed to modify cluster replica", err.Error())
-		} else {
-			state.Replica = plan.Replica
-			// Wait for RUNNING after replica change, using the remaining create context timeout
-			if deadline, ok := ctx.Deadline(); ok {
-				remaining := time.Until(deadline)
-				if waitErr := r.waitForStatus(ctx, remaining, state.ClusterId.ValueString(), "RUNNING"); waitErr != nil && !util.IsNetworkGiveUpError(waitErr) {
-					resp.Diagnostics.AddWarning("Cluster replica modified but not yet RUNNING", waitErr.Error())
-				}
-			}
 		}
 	}
 
@@ -702,39 +771,20 @@ func (r *ClusterResource) handleSecurityGroupsUpdate(ctx context.Context, plan, 
 // handleAutoscalingUpdate sends a single API call with the complete autoscaling state
 // (cu + replica) to avoid partial overwrites — the API replaces the entire autoscaling object.
 func (r *ClusterResource) handleAutoscalingUpdate(ctx context.Context, plan, state ClusterResourceModel) diag.Diagnostics {
-	var diags diag.Diagnostics
 	ptrInt := func(v int64) *int { i := int(v); return &i }
 
-	// Validate: dynamic_scaling and schedule_scaling are mutually exclusive within each settings block
-	if plan.CuSettings != nil && !plan.CuSettings.IsDynamicScalingNull() && !plan.CuSettings.IsSchedulesNull() {
-		diags.AddError("Invalid configuration", "cu_settings: cannot set both dynamic_scaling and schedule_scaling at the same time")
+	diags := validateAutoscalingSettings(plan)
+	if diags.HasError() {
 		return diags
-	}
-	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsDynamicScalingNull() && !plan.ReplicaSettings.IsSchedulesNull() {
-		diags.AddError("Invalid configuration", "replica_settings: cannot set both dynamic_scaling and schedule_scaling at the same time")
-		return diags
-	}
-
-	// Validate min <= max
-	if plan.CuSettings != nil && !plan.CuSettings.IsDynamicScalingNull() {
-		if plan.CuSettings.DynamicScaling.Min.ValueInt64() > plan.CuSettings.DynamicScaling.Max.ValueInt64() {
-			diags.AddError("Invalid autoscaling configuration", fmt.Sprintf(
-				"cu_settings: min (%d) must be <= max (%d)",
-				plan.CuSettings.DynamicScaling.Min.ValueInt64(), plan.CuSettings.DynamicScaling.Max.ValueInt64()))
-			return diags
-		}
-	}
-	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsDynamicScalingNull() {
-		if plan.ReplicaSettings.DynamicScaling.Min.ValueInt64() > plan.ReplicaSettings.DynamicScaling.Max.ValueInt64() {
-			diags.AddError("Invalid autoscaling configuration", fmt.Sprintf(
-				"replica_settings: min (%d) must be <= max (%d)",
-				plan.ReplicaSettings.DynamicScaling.Min.ValueInt64(), plan.ReplicaSettings.DynamicScaling.Max.ValueInt64()))
-			return diags
-		}
 	}
 
 	// Build the combined payload
-	params := &zilliz.ModifyAutoscalingCombinedParams{}
+	params := &zilliz.ModifyAutoscalingCombinedParams{
+		Autoscaling: zilliz.AutoscalingConfig{
+			CU:      &zilliz.AutoscalingPolicy{},
+			Replica: &zilliz.AutoscalingPolicy{},
+		},
+	}
 
 	if plan.CuSettings != nil && !plan.CuSettings.IsDynamicScalingNull() {
 		params.Autoscaling.CU.Min = ptrInt(plan.CuSettings.DynamicScaling.Min.ValueInt64())
@@ -745,7 +795,7 @@ func (r *ClusterResource) handleAutoscalingUpdate(ctx context.Context, plan, sta
 		for i, s := range plan.CuSettings.ScheduleScaling {
 			schedules[i] = zilliz.ScheduleConfig{Timezone: s.Timezone.ValueString(), Cron: s.Cron.ValueString(), Target: int(s.Target.ValueInt64())}
 		}
-		params.Autoscaling.CU.Schedules = &schedules
+		params.Autoscaling.CU.Schedules = schedules
 	}
 
 	if plan.ReplicaSettings != nil && !plan.ReplicaSettings.IsDynamicScalingNull() {
@@ -757,7 +807,7 @@ func (r *ClusterResource) handleAutoscalingUpdate(ctx context.Context, plan, sta
 		for i, s := range plan.ReplicaSettings.ScheduleScaling {
 			schedules[i] = zilliz.ScheduleConfig{Timezone: s.Timezone.ValueString(), Cron: s.Cron.ValueString(), Target: int(s.Target.ValueInt64())}
 		}
-		params.Autoscaling.Replica.Schedules = &schedules
+		params.Autoscaling.Replica.Schedules = schedules
 	}
 
 	err := r.store.ModifyAutoscaling(ctx, state.ClusterId.ValueString(), params)
@@ -775,6 +825,11 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	updateTimeout, timeoutDiags := plan.Timeouts.Update(ctx, defaultClusterUpdateTimeout)
 	resp.Diagnostics.Append(timeoutDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(validateAutoscalingSettings(plan)...)
+	resp.Diagnostics.Append(validateReplicaPlan(plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/cluster/model_autoscaling_test.go
+++ b/internal/cluster/model_autoscaling_test.go
@@ -167,3 +167,86 @@ func TestCompleteReplicaAfterCreateKeepsConfiguredReplica(t *testing.T) {
 		t.Fatalf("replica = %d, want 2", got)
 	}
 }
+
+func TestShouldConfigureAutoscalingAfterCreate(t *testing.T) {
+	tests := []struct {
+		name string
+		plan ClusterResourceModel
+		want bool
+	}{
+		{
+			name: "cu dynamic only is handled by create",
+			plan: ClusterResourceModel{
+				CuSettings: &CuSettings{DynamicScaling: &DynamicScaling{
+					Min: types.Int64Value(2),
+					Max: types.Int64Value(4),
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "cu schedule needs post create update",
+			plan: ClusterResourceModel{
+				CuSettings: &CuSettings{ScheduleScaling: []ScheduleScaling{
+					{Timezone: types.StringValue("UTC"), Cron: types.StringValue("0 0 * * *"), Target: types.Int64Value(2)},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "replica dynamic needs post create update",
+			plan: ClusterResourceModel{
+				ReplicaSettings: &ReplicaSettings{DynamicScaling: &DynamicScaling{
+					Min: types.Int64Value(1),
+					Max: types.Int64Value(2),
+				}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldConfigureAutoscalingAfterCreate(tt.plan); got != tt.want {
+				t.Fatalf("shouldConfigureAutoscalingAfterCreate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateReplicaPlanRequiresEnterpriseForMultiReplica(t *testing.T) {
+	plan := ClusterResourceModel{
+		Plan:    types.StringValue(StandardPlan),
+		Replica: types.Int64Value(2),
+	}
+
+	if diags := validateReplicaPlan(plan); !diags.HasError() {
+		t.Fatal("expected Standard plan with replica > 1 to be rejected")
+	}
+}
+
+func TestValidateReplicaPlanAllowsBusinessCriticalForMultiReplica(t *testing.T) {
+	plan := ClusterResourceModel{
+		Plan:    types.StringValue(BusinessCriticalPlan),
+		Replica: types.Int64Value(2),
+	}
+
+	if diags := validateReplicaPlan(plan); diags.HasError() {
+		t.Fatalf("expected BusinessCritical plan with replica > 1 to be allowed: %v", diags)
+	}
+}
+
+func TestValidateAutoscalingSettingsRequiresDynamicMinAndMax(t *testing.T) {
+	plan := ClusterResourceModel{
+		CuSettings: &CuSettings{
+			DynamicScaling: &DynamicScaling{
+				Min: types.Int64Value(2),
+				Max: types.Int64Null(),
+			},
+		},
+	}
+
+	if diags := validateAutoscalingSettings(plan); !diags.HasError() {
+		t.Fatal("expected incomplete dynamic_scaling to be rejected")
+	}
+}

--- a/internal/cluster/store.go
+++ b/internal/cluster/store.go
@@ -40,14 +40,14 @@ func (c *ClusterStoreImpl) Get(ctx context.Context, clusterId string) (*ClusterR
 
 	// Parse CU autoscaling
 	var cuDynamic *DynamicScaling
-	if cluster.Autoscaling.CU.Min != nil && cluster.Autoscaling.CU.Max != nil {
+	if cluster.Autoscaling.CU != nil && cluster.Autoscaling.CU.Min != nil && cluster.Autoscaling.CU.Max != nil {
 		cuDynamic = &DynamicScaling{
 			Min: types.Int64Value(int64(*cluster.Autoscaling.CU.Min)),
 			Max: types.Int64Value(int64(*cluster.Autoscaling.CU.Max)),
 		}
 	}
 	var cuSchedules []ScheduleScaling
-	if len(cluster.Autoscaling.CU.Schedules) > 0 {
+	if cluster.Autoscaling.CU != nil && len(cluster.Autoscaling.CU.Schedules) > 0 {
 		cuSchedules = make([]ScheduleScaling, len(cluster.Autoscaling.CU.Schedules))
 		for i, s := range cluster.Autoscaling.CU.Schedules {
 			cuSchedules[i] = ScheduleScaling{
@@ -67,14 +67,14 @@ func (c *ClusterStoreImpl) Get(ctx context.Context, clusterId string) (*ClusterR
 
 	// Parse Replica autoscaling
 	var replicaDynamic *DynamicScaling
-	if cluster.Autoscaling.Replica.Min != nil && cluster.Autoscaling.Replica.Max != nil {
+	if cluster.Autoscaling.Replica != nil && cluster.Autoscaling.Replica.Min != nil && cluster.Autoscaling.Replica.Max != nil {
 		replicaDynamic = &DynamicScaling{
 			Min: types.Int64Value(int64(*cluster.Autoscaling.Replica.Min)),
 			Max: types.Int64Value(int64(*cluster.Autoscaling.Replica.Max)),
 		}
 	}
 	var replicaSchedules []ScheduleScaling
-	if len(cluster.Autoscaling.Replica.Schedules) > 0 {
+	if cluster.Autoscaling.Replica != nil && len(cluster.Autoscaling.Replica.Schedules) > 0 {
 		replicaSchedules = make([]ScheduleScaling, len(cluster.Autoscaling.Replica.Schedules))
 		for i, s := range cluster.Autoscaling.Replica.Schedules {
 			replicaSchedules[i] = ScheduleScaling{
@@ -135,6 +135,7 @@ func (c *ClusterStoreImpl) Get(ctx context.Context, clusterId string) (*ClusterR
 
 func (c *ClusterStoreImpl) Create(ctx context.Context, cluster *ClusterResourceModel) (ret *ClusterResourceModel, err error) {
 	var response *zilliz.CreateClusterResponse
+	ptrInt := func(v int64) *int { i := int(v); return &i }
 
 	regionId := cluster.RegionId.ValueString()
 	if cluster.RegionId.IsNull() || cluster.RegionId.ValueString() == "" {
@@ -182,8 +183,7 @@ func (c *ClusterStoreImpl) Create(ctx context.Context, cluster *ClusterResourceM
 			awsCseKeyArn = conv.StringPtr(cluster.AwsCseKeyArn.ValueString())
 		}
 
-		// dedicated:
-		response, err = c.client.CreateDedicatedCluster(zilliz.CreateClusterParams{
+		params := zilliz.CreateClusterParams{
 			RegionId: regionId,
 			Plan: func() *string {
 				if cluster.Plan.IsNull() || cluster.Plan.IsUnknown() {
@@ -191,19 +191,33 @@ func (c *ClusterStoreImpl) Create(ctx context.Context, cluster *ClusterResourceM
 				}
 				return conv.StringPtr(cluster.Plan.ValueString())
 			}(),
-			ClusterName: cluster.ClusterName.ValueString(),
-			CUSize: func() int {
-				if cluster.CuSize.IsNull() || cluster.CuSize.IsUnknown() {
-					return 1
-				}
-				return int(cluster.CuSize.ValueInt64())
-			}(),
+			ClusterName:  cluster.ClusterName.ValueString(),
 			CUType:       cluster.CuType.ValueString(),
 			ProjectId:    cluster.ProjectId.ValueString(),
 			Labels:       labels,
 			BucketInfo:   bucketInfo,
 			AwsCseKeyArn: awsCseKeyArn,
-		})
+		}
+		if cluster.CuSettings != nil && !cluster.CuSettings.IsDynamicScalingNull() {
+			params.Autoscaling = &zilliz.AutoscalingConfig{
+				CU: &zilliz.AutoscalingPolicy{
+					Min: ptrInt(cluster.CuSettings.DynamicScaling.Min.ValueInt64()),
+					Max: ptrInt(cluster.CuSettings.DynamicScaling.Max.ValueInt64()),
+				},
+			}
+		} else {
+			if cluster.CuSize.IsNull() || cluster.CuSize.IsUnknown() {
+				params.CUSize = ptrInt(1)
+			} else {
+				params.CUSize = ptrInt(cluster.CuSize.ValueInt64())
+			}
+		}
+		if !cluster.Replica.IsNull() && !cluster.Replica.IsUnknown() {
+			params.Replica = ptrInt(cluster.Replica.ValueInt64())
+		}
+
+		// dedicated:
+		response, err = c.client.CreateDedicatedCluster(params)
 	}
 
 	if err != nil {

--- a/mock-server/pkg/byoc_project/cluster.go
+++ b/mock-server/pkg/byoc_project/cluster.go
@@ -30,6 +30,16 @@ func CreateDedicatedCluster(c *gin.Context) {
 		clusterId = request.ClusterId
 	}
 	connectAddress := fmt.Sprintf("https://%s.%s.vectordb-uat3.zillizcloud.com:19540", clusterId, request.RegionId)
+	cuSize := 1
+	if request.CuSize != nil {
+		cuSize = *request.CuSize
+	} else if request.Autoscaling.CU.Min != nil {
+		cuSize = *request.Autoscaling.CU.Min
+	}
+	replica := 1
+	if request.Replica != nil {
+		replica = *request.Replica
+	}
 
 	cluster := &DedicatedClusterResponse{
 		ClusterId:   clusterId,
@@ -53,7 +63,7 @@ func CreateDedicatedCluster(c *gin.Context) {
 		ConnectAddress:     connectAddress,
 		PrivateLinkAddress: "",
 		CreateTime:         time.Now().Format(time.RFC3339),
-		CuSize:             request.CuSize,
+		CuSize:             cuSize,
 		StorageSize:        0,
 		SnapshotNumber:     0,
 		CreateProgress:     100,
@@ -68,9 +78,8 @@ func CreateDedicatedCluster(c *gin.Context) {
 			}
 			return ""
 		}(),
-	}
-	if cluster.Plan == "Standard" || cluster.Plan == "Enterprise" {
-		cluster.Replica = 1
+		Replica:     replica,
+		Autoscaling: request.Autoscaling,
 	}
 	cluster.Status = "CREATING"
 	clusterStore.Set(clusterId, cluster)

--- a/mock-server/pkg/byoc_project/model.go
+++ b/mock-server/pkg/byoc_project/model.go
@@ -405,8 +405,9 @@ type CreateDedicatedClusterRequest struct {
 	RegionId     string             `json:"regionId"`
 	CuType       string             `json:"cuType"`
 	Plan         *string            `json:"plan,omitempty"`
-	Replica      int                `json:"replica"`
-	CuSize       int                `json:"cuSize"`
+	Replica      *int               `json:"replica,omitempty"`
+	CuSize       *int               `json:"cuSize,omitempty"`
+	Autoscaling  Autoscaling        `json:"autoscaling"`
 	Labels       map[string]string  `json:"labels"`
 	BucketInfo   *ClusterBucketInfo `json:"bucketInfo,omitempty"`
 	AwsCseKeyArn *string            `json:"keyIdentifier,omitempty"`


### PR DESCRIPTION
## Summary
- send create-time replica and CU autoscaling in dedicated cluster create requests
- omit cuSize when autoscaling.cu is used, while preserving fixed-CU create payloads
- keep schedule/replica autoscaling on the post-create modify path and validate multi-replica as Enterprise or BusinessCritical only
- reuse a shared autoscaling client model and update mock-server handling

## Tests
- go test ./client ./internal/cluster
- (cd mock-server && go test ./...)
- git diff --check
- go test ./... (fails in existing internal/provider TestVolumeResourceDeleteReportsTimeout: expected timeout diagnostics)