### PR TITLE
feat(byoc-i): expose tunnelClientImageUrl in op_config

### DIFF
--- a/client/byoc_op_project.go
+++ b/client/byoc_op_project.go
@@ -80,8 +80,9 @@ type DescribeByocOpProjectResponse struct {
 	RegionID        string      `json:"regionId"`
 	Status          int         `json:"status"`
 	OpConfig        *struct {
-		Token         string `json:"token"`
-		AgentImageUrl string `json:"agentImageUrl"`
+		Token                string `json:"token"`
+		AgentImageUrl        string `json:"agentImageUrl"`
+		TunnelClientImageUrl string `json:"tunnelClientImageUrl"`
 	} `json:"vpcOpConfig"`
 	Mode int `json:"mode"`
 }

--- a/client/byoc_op_project_setting.go
+++ b/client/byoc_op_project_setting.go
@@ -59,9 +59,10 @@ type GetByocOpProjectSettingsResponse struct {
 }
 
 type OpConfig struct {
-	Token         string `json:"tunnelToken"`
-	AgentImageUrl string `json:"agentImageUrl"`
-	ExtConfig     string `json:"extConfig"`
+	Token                string `json:"tunnelToken"`
+	AgentImageUrl        string `json:"agentImageUrl"`
+	TunnelClientImageUrl string `json:"tunnelClientImageUrl"`
+	ExtConfig            string `json:"extConfig"`
 }
 
 type NodeQuota struct {

--- a/docs/data-sources/byoc_i_project_settings.md
+++ b/docs/data-sources/byoc_i_project_settings.md
@@ -101,6 +101,7 @@ Read-Only:
 
 - `agent_image_url` (String) Agent image URL
 - `token` (String) Operation token
+- `tunnel_client_image_url` (String) Tunnel client image URL
 
 
 <a id="nestedatt--tiered_node_quota"></a>

--- a/docs/resources/byoc_i_project_settings.md
+++ b/docs/resources/byoc_i_project_settings.md
@@ -160,6 +160,7 @@ Read-Only:
 
 - `agent_image_url` (String) Agent image URL
 - `token` (String) Operation token
+- `tunnel_client_image_url` (String) Tunnel client image URL
 
 
 <a id="nestedatt--tiered_node_quota"></a>

--- a/internal/provider/byoc_i/projects_resource_model.go
+++ b/internal/provider/byoc_i/projects_resource_model.go
@@ -124,8 +124,9 @@ type BYOCOpProjectSettingsResourceModel struct {
 }
 
 type OpConfig struct {
-	Token         types.String `tfsdk:"token"`
-	AgentImageUrl types.String `tfsdk:"agent_image_url"`
+	Token                types.String `tfsdk:"token"`
+	AgentImageUrl        types.String `tfsdk:"agent_image_url"`
+	TunnelClientImageUrl types.String `tfsdk:"tunnel_client_image_url"`
 }
 
 type NodeQuotas struct {

--- a/internal/provider/byoc_i/projects_settings_data.go
+++ b/internal/provider/byoc_i/projects_settings_data.go
@@ -104,6 +104,10 @@ func (r *BYOCOpProjectSettingsData) Schema(ctx context.Context, req datasource.S
 						MarkdownDescription: "Agent image URL",
 						Computed:            true,
 					},
+					"tunnel_client_image_url": schema.StringAttribute{
+						MarkdownDescription: "Tunnel client image URL",
+						Computed:            true,
+					},
 				},
 			},
 			"node_quotas": schema.SingleNestedAttribute{
@@ -208,11 +212,13 @@ func (s *byocOpProjectSettingsDataStore) Describe(ctx context.Context, projectID
 		data.PrivateLinkEnabled = types.BoolValue(response.PrivateLinkEnabled == 1)
 
 		OpConfig, diag := types.ObjectValue(map[string]attr.Type{
-			"token":           types.StringType,
-			"agent_image_url": types.StringType,
+			"token":                   types.StringType,
+			"agent_image_url":         types.StringType,
+			"tunnel_client_image_url": types.StringType,
 		}, map[string]attr.Value{
-			"token":           types.StringValue(response.OpConfig.Token),
-			"agent_image_url": types.StringValue(response.OpConfig.AgentImageUrl),
+			"token":                   types.StringValue(response.OpConfig.Token),
+			"agent_image_url":         types.StringValue(response.OpConfig.AgentImageUrl),
+			"tunnel_client_image_url": types.StringValue(response.OpConfig.TunnelClientImageUrl),
 		})
 		if diag.HasError() {
 			return data, fmt.Errorf("failed to abstract OpConfig from response")

--- a/internal/provider/byoc_i/projects_settings_data_test.go
+++ b/internal/provider/byoc_i/projects_settings_data_test.go
@@ -52,6 +52,7 @@ data "zillizcloud_byoc_i_project_settings" "test" {
 					// Check op_config
 					resource.TestCheckResourceAttrSet("data.zillizcloud_byoc_i_project_settings.test", "op_config.token"),
 					resource.TestCheckResourceAttrSet("data.zillizcloud_byoc_i_project_settings.test", "op_config.agent_image_url"),
+					resource.TestCheckResourceAttrSet("data.zillizcloud_byoc_i_project_settings.test", "op_config.tunnel_client_image_url"),
 					resource.TestCheckResourceAttr("data.zillizcloud_byoc_i_project_settings.test", "private_link_enabled", "true"),
 				),
 			},

--- a/internal/provider/byoc_i/projects_settings_resource.go
+++ b/internal/provider/byoc_i/projects_settings_resource.go
@@ -155,6 +155,13 @@ func (r *BYOCOpProjectSettingsResource) Schema(ctx context.Context, req resource
 							stringplanmodifier.UseStateForUnknown(),
 						},
 					},
+					"tunnel_client_image_url": schema.StringAttribute{
+						MarkdownDescription: "Tunnel client image URL",
+						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
 				},
 			},
 			"node_quotas": schema.SingleNestedAttribute{

--- a/internal/provider/byoc_i/projects_settings_resource_test.go
+++ b/internal/provider/byoc_i/projects_settings_resource_test.go
@@ -52,6 +52,7 @@ resource "zillizcloud_byoc_i_project_settings" "test" {
 					// Check op_config
 					resource.TestCheckResourceAttrSet("zillizcloud_byoc_i_project_settings.test", "op_config.token"),
 					resource.TestCheckResourceAttrSet("zillizcloud_byoc_i_project_settings.test", "op_config.agent_image_url"),
+					resource.TestCheckResourceAttrSet("zillizcloud_byoc_i_project_settings.test", "op_config.tunnel_client_image_url"),
 				),
 			},
 		},

--- a/internal/provider/byoc_i/projects_settings_store.go
+++ b/internal/provider/byoc_i/projects_settings_store.go
@@ -130,11 +130,13 @@ func (s *byocOpProjectSettingsStore) Describe(ctx context.Context, projectID str
 		}
 		data.PrivateLinkEnabled = types.BoolValue(response.PrivateLinkEnabled == 1)
 		OpConfig, diag := types.ObjectValue(map[string]attr.Type{
-			"token":           types.StringType,
-			"agent_image_url": types.StringType,
+			"token":                   types.StringType,
+			"agent_image_url":         types.StringType,
+			"tunnel_client_image_url": types.StringType,
 		}, map[string]attr.Value{
-			"token":           types.StringValue(response.OpConfig.Token),
-			"agent_image_url": types.StringValue(response.OpConfig.AgentImageUrl),
+			"token":                   types.StringValue(response.OpConfig.Token),
+			"agent_image_url":         types.StringValue(response.OpConfig.AgentImageUrl),
+			"tunnel_client_image_url": types.StringValue(response.OpConfig.TunnelClientImageUrl),
 		})
 		if diag.HasError() {
 			return data, fmt.Errorf("failed to abstract OpConfig from response")

--- a/mock-server/pkg/byoc_project/dataplane.go
+++ b/mock-server/pkg/byoc_project/dataplane.go
@@ -263,7 +263,7 @@ func CreateSettings(c *gin.Context) {
 			WithNodeQuota("fundamental", int(request.FundamentalMin), []string{request.FundamentalVm}),
 			WithNodeQuota("core", int(request.CoreMin), []string{request.CoreVm}),
 		}),
-		WithOpConfig("sk-op-token", "sk-op-agent-image-url"),
+		WithOpConfig("sk-op-token", "sk-op-agent-image-url", "sk-op-tunnel-client-image-url"),
 	)
 
 	// could query by dataPlaneId or projectId later on

--- a/mock-server/pkg/byoc_project/model.go
+++ b/mock-server/pkg/byoc_project/model.go
@@ -297,8 +297,9 @@ type SettingsResponse struct {
 	NodeQuotas  []NodeQuota `json:"nodeQuotas"`
 	OpenPl      int         `json:"openPl"`
 	OpConfig    struct {
-		Token         string `json:"tunnelToken"`
-		AgentImageUrl string `json:"agentImageUrl"`
+		Token                string `json:"tunnelToken"`
+		AgentImageUrl        string `json:"agentImageUrl"`
+		TunnelClientImageUrl string `json:"tunnelClientImageUrl"`
 	} `json:"opConfig"`
 }
 
@@ -382,10 +383,11 @@ func WithNodeQuota(Name string, min int, instanceTypes []string) NodeQuota {
 	}
 }
 
-func WithOpConfig(token string, agentImageUrl string) Option {
+func WithOpConfig(token string, agentImageUrl string, tunnelClientImageUrl string) Option {
 	return func(s *SettingsResponse) {
 		s.OpConfig.Token = token
 		s.OpConfig.AgentImageUrl = agentImageUrl
+		s.OpConfig.TunnelClientImageUrl = tunnelClientImageUrl
 	}
 }
 


### PR DESCRIPTION
## 背景
控制面将 **tunnel-client** 逻辑从 cloud-agent 镜像中拆分为独立镜像，`GET byoc/op/dataplane/setting` 在 `agentImageUrl` 之外新增返回 `tunnelClientImageUrl`。Provider 需要解析并暴露该字段，供下游 examples / booter 部署 tunnel-client sidecar 使用。

## 改动
- `client/byoc_op_project_setting.go`、`client/byoc_op_project.go`：`OpConfig` / `vpcOpConfig` 新增 `TunnelClientImageUrl`
- data source + resource：schema、ObjectValue、resource model 三处新增 `op_config.tunnel_client_image_url`（attr type 与 value 的 key 集合保持一致）
- mock-server：model + `WithOpConfig` 签名 + 调用点
- 单测断言（data source / resource）+ 文档（docs/）

## 兼容性
- 控制面未返回该字段时为空串（零值），不报错。
- **不处理** `metricsImageUrl`（按需求确认）。

## 验证
- `go build ./...`、`go vet`、`client` 包单测均通过。
- mock-server 模块单独 build/vet 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)