### PR TITLE
feat(global-cluster): support scaling options on create

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
-          terraform_version: '1.8.0-alpha20240216'
+          terraform_version: '1.8.5'
           terraform_wrapper: false
       - run: go mod download
       - name: Wait for mock server to be ready
@@ -94,6 +94,7 @@ jobs:
           ZILLIZCLOUD_API_KEY: "xxxxxxxxxxx"
           ZILLIZCLOUD_QPS: "1000"
           ZILLIZCLOUD_BURST: "1000"
+          ZILLIZCLOUD_PROJECT_ID: "proj-ebc5ac7f430702aec8c57b"
           TF_ACC: "1"
         run: go test -v ./internal/cluster   
         timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+        with:
+          terraform_version: '1.8.0-alpha20240216'
+          terraform_wrapper: false
       - run: go mod download
       - name: Wait for mock server to be ready
         run: |

--- a/client/global_cluster.go
+++ b/client/global_cluster.go
@@ -5,13 +5,15 @@ import "fmt"
 type GlobalClusterMemberParams struct {
 	ClusterName string `json:"clusterName"`
 	RegionId    string `json:"regionId"`
+	Replica     *int   `json:"replica,omitempty"`
 }
 
 type CreateGlobalClusterParams struct {
 	GlobalClusterName string                      `json:"globalClusterName"`
 	ProjectId         string                      `json:"projectId"`
 	CuType            string                      `json:"cuType"`
-	CuSize            int                         `json:"cuSize"`
+	CuSize            int                         `json:"cuSize,omitempty"`
+	Autoscaling       *AutoscalingConfig          `json:"autoscaling,omitempty"`
 	PrimaryCluster    GlobalClusterMemberParams   `json:"primaryCluster"`
 	SecondaryClusters []GlobalClusterMemberParams `json:"secondaryClusters"`
 }
@@ -30,6 +32,7 @@ type GlobalCluster struct {
 	RegionIds         []string              `json:"regionIds"`
 	CuType            string                `json:"cuType"`
 	CuSize            int64                 `json:"cuSize"`
+	Autoscaling       AutoscalingConfig     `json:"autoscaling"`
 	ConnectAddress    string                `json:"connectAddress"`
 	CreateTime        string                `json:"createTime"`
 	Clusters          []GlobalClusterMember `json:"clusters"`
@@ -41,6 +44,7 @@ type GlobalClusterMember struct {
 	RegionId    string `json:"regionId"`
 	Role        string `json:"role"`
 	Status      string `json:"status"`
+	Replica     int64  `json:"replica,omitempty"`
 }
 
 type ModifyGlobalClusterCUParams struct {

--- a/docs/resources/global_cluster.md
+++ b/docs/resources/global_cluster.md
@@ -28,16 +28,31 @@ resource "zillizcloud_global_cluster" "example" {
   global_cluster_name = "example-global-cluster"
   project_id          = "proj-ebc5ac7f430702aec8c57b"
   cu_type             = "Performance-optimized"
-  cu_size             = 1
+
+  cu_settings = {
+    dynamic_scaling = {
+      min = 4
+      max = 8
+    }
+  }
+
+  replica_settings = {
+    dynamic_scaling = {
+      min = 1
+      max = 3
+    }
+  }
 
   cluster = [
     {
       cluster_name = "example-primary"
       region_id    = "aws-us-west-2"
+      replica      = 2
     },
     {
       cluster_name = "example-secondary-eu"
       region_id    = "aws-eu-west-1"
+      replica      = 1
     }
   ]
 }
@@ -49,13 +64,15 @@ resource "zillizcloud_global_cluster" "example" {
 ### Required
 
 - `cluster` (Attributes List) Ordered member cluster parameters. The first item is the primary cluster; all remaining items are secondary clusters. Updates may add or remove secondary clusters, but existing members cannot be modified in place. (see [below for nested schema](#nestedatt--cluster))
-- `cu_size` (Number) CU size shared by primary and secondary clusters.
 - `global_cluster_name` (String) Global cluster display name.
 - `project_id` (String) Project ID where the global cluster is created.
 
 ### Optional
 
+- `cu_settings` (Attributes) Dynamic CU autoscaling shared by all member clusters. Cannot be set with cu_size. Changing this configuration replaces the global cluster. (see [below for nested schema](#nestedatt--cu_settings))
+- `cu_size` (Number) Fixed CU size shared by primary and secondary clusters. Cannot be set with cu_settings.
 - `cu_type` (String) CU type shared by primary and secondary clusters.
+- `replica_settings` (Attributes) Dynamic replica autoscaling policy synchronized to every member cluster. Changing this configuration replaces the global cluster. (see [below for nested schema](#nestedatt--replica_settings))
 
 ### Read-Only
 
@@ -75,8 +92,45 @@ Required:
 - `cluster_name` (String) Member cluster name.
 - `region_id` (String) Member cluster region ID.
 
+Optional:
+
+- `replica` (Number) Initial fixed replica count for this member. Values greater than 1 require an Enterprise or Business Critical project. Changing this value replaces the global cluster.
+
 Read-Only:
 
 - `cluster_id` (String) Member cluster identifier assigned by the Global Cluster API.
 - `role` (String) Member role. Values are PRIMARY and SECONDARY.
 - `status` (String) Current member cluster status.
+
+
+<a id="nestedatt--cu_settings"></a>
+### Nested Schema for `cu_settings`
+
+Required:
+
+- `dynamic_scaling` (Attributes) Dynamic scaling bounds for CU. (see [below for nested schema](#nestedatt--cu_settings--dynamic_scaling))
+
+<a id="nestedatt--cu_settings--dynamic_scaling"></a>
+### Nested Schema for `cu_settings.dynamic_scaling`
+
+Required:
+
+- `max` (Number) Maximum CU value. Must be greater than or equal to min.
+- `min` (Number) Minimum CU value.
+
+
+
+<a id="nestedatt--replica_settings"></a>
+### Nested Schema for `replica_settings`
+
+Required:
+
+- `dynamic_scaling` (Attributes) Dynamic scaling bounds for replica. (see [below for nested schema](#nestedatt--replica_settings--dynamic_scaling))
+
+<a id="nestedatt--replica_settings--dynamic_scaling"></a>
+### Nested Schema for `replica_settings.dynamic_scaling`
+
+Required:
+
+- `max` (Number) Maximum replica value. Must be greater than or equal to min.
+- `min` (Number) Minimum replica value.

--- a/examples/resources/zillizcloud_global_cluster/resource.tf
+++ b/examples/resources/zillizcloud_global_cluster/resource.tf
@@ -13,16 +13,31 @@ resource "zillizcloud_global_cluster" "example" {
   global_cluster_name = "example-global-cluster"
   project_id          = "proj-ebc5ac7f430702aec8c57b"
   cu_type             = "Performance-optimized"
-  cu_size             = 1
+
+  cu_settings = {
+    dynamic_scaling = {
+      min = 4
+      max = 8
+    }
+  }
+
+  replica_settings = {
+    dynamic_scaling = {
+      min = 1
+      max = 3
+    }
+  }
 
   cluster = [
     {
       cluster_name = "example-primary"
       region_id    = "aws-us-west-2"
+      replica      = 2
     },
     {
       cluster_name = "example-secondary-eu"
       region_id    = "aws-eu-west-1"
+      replica      = 1
     }
   ]
 }

--- a/internal/cluster/cluster_load_balancer_security_groups_resource_test.go
+++ b/internal/cluster/cluster_load_balancer_security_groups_resource_test.go
@@ -15,7 +15,7 @@ func TestAccClusterLoadBalancerSecurityGroupsResource(t *testing.T) {
 			{
 				Config: provider.ProviderConfig + `
 data "zillizcloud_project" "default" {
-  id = "proj-test123456789"
+  id = "proj-ebc5ac7f430702aec8c57b"
 }
 
 resource "zillizcloud_cluster" "test" {
@@ -52,7 +52,7 @@ resource "zillizcloud_cluster_load_balancer_security_groups" "test" {
 			{
 				Config: provider.ProviderConfig + `
 data "zillizcloud_project" "default" {
-  id = "proj-test123456789"
+  id = "proj-ebc5ac7f430702aec8c57b"
 }
 
 resource "zillizcloud_cluster" "test" {
@@ -83,7 +83,7 @@ resource "zillizcloud_cluster_load_balancer_security_groups" "test" {
 			{
 				Config: provider.ProviderConfig + `
 data "zillizcloud_project" "default" {
-  id = "proj-test123456789"
+  id = "proj-ebc5ac7f430702aec8c57b"
 }
 
 resource "zillizcloud_cluster" "test" {

--- a/internal/global_cluster/model.go
+++ b/internal/global_cluster/model.go
@@ -23,9 +23,20 @@ type GlobalCluster struct {
 	RegionIDs         []string
 	CUType            string
 	CUSize            int64
+	Autoscaling       GlobalClusterAutoscaling
 	ConnectAddress    string
 	CreateTime        string
 	Clusters          []GlobalClusterMember
+}
+
+type GlobalClusterAutoscaling struct {
+	CU      *GlobalClusterAutoscalingPolicy
+	Replica *GlobalClusterAutoscalingPolicy
+}
+
+type GlobalClusterAutoscalingPolicy struct {
+	Min *int64
+	Max *int64
 }
 
 type GlobalClusterMember struct {
@@ -34,6 +45,7 @@ type GlobalClusterMember struct {
 	RegionID    string
 	Role        GlobalClusterMemberRole
 	Status      string
+	Replica     int64
 }
 
 func (m GlobalClusterMember) isRunning() bool {
@@ -43,6 +55,7 @@ func (m GlobalClusterMember) isRunning() bool {
 type GlobalClusterMemberSpec struct {
 	ClusterName string
 	RegionID    string
+	Replica     *int64
 }
 
 type CreateGlobalClusterCommand struct {
@@ -50,6 +63,7 @@ type CreateGlobalClusterCommand struct {
 	ProjectID         string
 	CUType            string
 	CUSize            int64
+	Autoscaling       GlobalClusterAutoscaling
 	Members           []GlobalClusterMemberSpec
 }
 
@@ -161,6 +175,7 @@ func GlobalClusterFromAPI(api *zilliz.GlobalCluster) *GlobalCluster {
 			RegionID:    member.RegionId,
 			Role:        GlobalClusterMemberRole(member.Role),
 			Status:      member.Status,
+			Replica:     member.Replica,
 		})
 	}
 
@@ -171,10 +186,32 @@ func GlobalClusterFromAPI(api *zilliz.GlobalCluster) *GlobalCluster {
 		RegionIDs:         append([]string(nil), api.RegionIds...),
 		CUType:            api.CuType,
 		CUSize:            api.CuSize,
-		ConnectAddress:    api.ConnectAddress,
-		CreateTime:        api.CreateTime,
-		Clusters:          clusters,
+		Autoscaling: GlobalClusterAutoscaling{
+			CU:      globalClusterAutoscalingPolicyFromAPI(api.Autoscaling.CU),
+			Replica: globalClusterAutoscalingPolicyFromAPI(api.Autoscaling.Replica),
+		},
+		ConnectAddress: api.ConnectAddress,
+		CreateTime:     api.CreateTime,
+		Clusters:       clusters,
 	}
+}
+
+func globalClusterAutoscalingPolicyFromAPI(policy *zilliz.AutoscalingPolicy) *GlobalClusterAutoscalingPolicy {
+	if policy == nil {
+		return nil
+	}
+	return &GlobalClusterAutoscalingPolicy{
+		Min: int64Pointer(policy.Min),
+		Max: int64Pointer(policy.Max),
+	}
+}
+
+func int64Pointer(value *int) *int64 {
+	if value == nil {
+		return nil
+	}
+	converted := int64(*value)
+	return &converted
 }
 
 func IsNotFoundError(err error) bool {

--- a/internal/global_cluster/resource.go
+++ b/internal/global_cluster/resource.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -27,9 +29,10 @@ var (
 )
 
 var (
-	_ resource.Resource                = &GlobalClusterResource{}
-	_ resource.ResourceWithConfigure   = &GlobalClusterResource{}
-	_ resource.ResourceWithImportState = &GlobalClusterResource{}
+	_ resource.Resource                     = &GlobalClusterResource{}
+	_ resource.ResourceWithConfigure        = &GlobalClusterResource{}
+	_ resource.ResourceWithConfigValidators = &GlobalClusterResource{}
+	_ resource.ResourceWithImportState      = &GlobalClusterResource{}
 )
 
 func NewGlobalClusterResource() resource.Resource {
@@ -91,6 +94,15 @@ func (r *GlobalClusterResource) Metadata(ctx context.Context, req resource.Metad
 	resp.TypeName = req.ProviderTypeName + "_global_cluster"
 }
 
+func (r *GlobalClusterResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("cu_size"),
+			path.MatchRoot("cu_settings"),
+		),
+	}
+}
+
 func (r *GlobalClusterResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a Zilliz Cloud Global Cluster. The first cluster entry is created as the primary cluster, and every subsequent entry is created as a secondary cluster.",
@@ -129,8 +141,9 @@ func (r *GlobalClusterResource) Schema(ctx context.Context, req resource.SchemaR
 				},
 			},
 			"cu_size": schema.Int64Attribute{
-				MarkdownDescription: "CU size shared by primary and secondary clusters.",
-				Required:            true,
+				MarkdownDescription: "Fixed CU size shared by primary and secondary clusters. Cannot be set with cu_settings.",
+				Optional:            true,
+				Computed:            true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
@@ -138,6 +151,14 @@ func (r *GlobalClusterResource) Schema(ctx context.Context, req resource.SchemaR
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
+			"cu_settings": globalClusterScalingNestedAttribute(
+				"Dynamic CU autoscaling shared by all member clusters. Cannot be set with cu_size. Changing this configuration replaces the global cluster.",
+				"CU",
+			),
+			"replica_settings": globalClusterScalingNestedAttribute(
+				"Dynamic replica autoscaling policy synchronized to every member cluster. Changing this configuration replaces the global cluster.",
+				"replica",
+			),
 			"cluster": globalClusterMembersNestedAttribute(),
 			"connect_address": schema.StringAttribute{
 				MarkdownDescription: "Global endpoint address.",
@@ -184,6 +205,38 @@ func (r *GlobalClusterResource) Schema(ctx context.Context, req resource.SchemaR
 	}
 }
 
+func globalClusterScalingNestedAttribute(description string, target string) schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: description,
+		Optional:            true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.RequiresReplace(),
+		},
+		Attributes: map[string]schema.Attribute{
+			"dynamic_scaling": schema.SingleNestedAttribute{
+				MarkdownDescription: fmt.Sprintf("Dynamic scaling bounds for %s.", target),
+				Required:            true,
+				Attributes: map[string]schema.Attribute{
+					"min": schema.Int64Attribute{
+						MarkdownDescription: fmt.Sprintf("Minimum %s value.", target),
+						Required:            true,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
+					},
+					"max": schema.Int64Attribute{
+						MarkdownDescription: fmt.Sprintf("Maximum %s value. Must be greater than or equal to min.", target),
+						Required:            true,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func globalClusterMembersNestedAttribute() schema.ListNestedAttribute {
 	return schema.ListNestedAttribute{
 		MarkdownDescription: "Ordered member cluster parameters. The first item is the primary cluster; all remaining items are secondary clusters. Updates may add or remove secondary clusters, but existing members cannot be modified in place.",
@@ -201,6 +254,18 @@ func globalClusterMembersNestedAttribute() schema.ListNestedAttribute {
 				"region_id": schema.StringAttribute{
 					MarkdownDescription: "Member cluster region ID.",
 					Required:            true,
+				},
+				"replica": schema.Int64Attribute{
+					MarkdownDescription: "Initial fixed replica count for this member. Values greater than 1 require an Enterprise or Business Critical project. Changing this value replaces the global cluster.",
+					Optional:            true,
+					Computed:            true,
+					PlanModifiers: []planmodifier.Int64{
+						int64planmodifier.UseStateForUnknown(),
+						int64planmodifier.RequiresReplace(),
+					},
+					Validators: []validator.Int64{
+						int64validator.AtLeast(1),
+					},
 				},
 				"role": schema.StringAttribute{
 					MarkdownDescription: "Member role. Values are PRIMARY and SECONDARY.",
@@ -237,12 +302,17 @@ func (r *GlobalClusterResource) Create(ctx context.Context, req resource.CreateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if err := validateGlobalClusterAutoscaling(data); err != nil {
+		resp.Diagnostics.AddError("Invalid global cluster autoscaling configuration", err.Error())
+		return
+	}
 
 	created, err := r.store.Create(ctx, CreateGlobalClusterCommand{
 		GlobalClusterName: data.GlobalClusterName.ValueString(),
 		ProjectID:         data.ProjectID.ValueString(),
 		CUType:            data.CUType.ValueString(),
 		CUSize:            data.CUSize.ValueInt64(),
+		Autoscaling:       data.autoscaling(),
 		Members:           data.memberSpecs(),
 	})
 	if err != nil {
@@ -273,6 +343,30 @@ func (r *GlobalClusterResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func validateGlobalClusterAutoscaling(data GlobalClusterResourceModel) error {
+	settings := []struct {
+		name  string
+		value *GlobalClusterScalingModel
+	}{
+		{name: "cu_settings", value: data.CUSettings},
+		{name: "replica_settings", value: data.ReplicaSettings},
+	}
+	for _, setting := range settings {
+		if setting.value == nil || setting.value.DynamicScaling == nil {
+			continue
+		}
+		minimum := setting.value.DynamicScaling.Min
+		maximum := setting.value.DynamicScaling.Max
+		if minimum.IsNull() || minimum.IsUnknown() || maximum.IsNull() || maximum.IsUnknown() {
+			continue
+		}
+		if minimum.ValueInt64() > maximum.ValueInt64() {
+			return fmt.Errorf("%s min (%d) must be less than or equal to max (%d)", setting.name, minimum.ValueInt64(), maximum.ValueInt64())
+		}
+	}
+	return nil
 }
 
 func (r *GlobalClusterResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/global_cluster/resource_model.go
+++ b/internal/global_cluster/resource_model.go
@@ -13,6 +13,8 @@ type GlobalClusterResourceModel struct {
 	ProjectID         types.String               `tfsdk:"project_id"`
 	CUType            types.String               `tfsdk:"cu_type"`
 	CUSize            types.Int64                `tfsdk:"cu_size"`
+	CUSettings        *GlobalClusterScalingModel `tfsdk:"cu_settings"`
+	ReplicaSettings   *GlobalClusterScalingModel `tfsdk:"replica_settings"`
 	Cluster           []GlobalClusterMemberModel `tfsdk:"cluster"`
 	ConnectAddress    types.String               `tfsdk:"connect_address"`
 	CreateTime        types.String               `tfsdk:"create_time"`
@@ -22,12 +24,22 @@ type GlobalClusterResourceModel struct {
 	CreateJobID       types.String               `tfsdk:"create_job_id"`
 }
 
+type GlobalClusterScalingModel struct {
+	DynamicScaling *GlobalClusterDynamicScalingModel `tfsdk:"dynamic_scaling"`
+}
+
+type GlobalClusterDynamicScalingModel struct {
+	Min types.Int64 `tfsdk:"min"`
+	Max types.Int64 `tfsdk:"max"`
+}
+
 type GlobalClusterMemberModel struct {
 	ClusterID   types.String `tfsdk:"cluster_id"`
 	ClusterName types.String `tfsdk:"cluster_name"`
 	RegionID    types.String `tfsdk:"region_id"`
 	Role        types.String `tfsdk:"role"`
 	Status      types.String `tfsdk:"status"`
+	Replica     types.Int64  `tfsdk:"replica"`
 }
 
 func (data *GlobalClusterResourceModel) applyGlobalCluster(ctx context.Context, globalCluster *GlobalCluster, appendDiags func(...diag.Diagnostic)) {
@@ -39,7 +51,13 @@ func (data *GlobalClusterResourceModel) applyGlobalCluster(ctx context.Context, 
 	data.GlobalClusterName = types.StringValue(globalCluster.GlobalClusterName)
 	data.ProjectID = types.StringValue(globalCluster.ProjectID)
 	data.CUType = types.StringValue(globalCluster.CUType)
-	data.CUSize = types.Int64Value(globalCluster.CUSize)
+	data.CUSettings = globalClusterScalingModel(globalCluster.Autoscaling.CU)
+	if data.CUSettings == nil {
+		data.CUSize = types.Int64Value(globalCluster.CUSize)
+	} else {
+		data.CUSize = types.Int64Null()
+	}
+	data.ReplicaSettings = globalClusterScalingModel(globalCluster.Autoscaling.Replica)
 	data.ConnectAddress = types.StringValue(globalCluster.ConnectAddress)
 	data.CreateTime = types.StringValue(globalCluster.CreateTime)
 
@@ -55,9 +73,52 @@ func (data *GlobalClusterResourceModel) applyGlobalCluster(ctx context.Context, 
 func (data GlobalClusterResourceModel) memberSpecs() []GlobalClusterMemberSpec {
 	specs := make([]GlobalClusterMemberSpec, 0, len(data.Cluster))
 	for _, member := range data.Cluster {
-		specs = append(specs, GlobalClusterMemberSpec{ClusterName: member.ClusterName.ValueString(), RegionID: member.RegionID.ValueString()})
+		specs = append(specs, GlobalClusterMemberSpec{
+			ClusterName: member.ClusterName.ValueString(),
+			RegionID:    member.RegionID.ValueString(),
+			Replica:     terraformInt64Pointer(member.Replica),
+		})
 	}
 	return specs
+}
+
+func (data GlobalClusterResourceModel) autoscaling() GlobalClusterAutoscaling {
+	return GlobalClusterAutoscaling{
+		CU:      data.CUSettings.autoscalingPolicy(),
+		Replica: data.ReplicaSettings.autoscalingPolicy(),
+	}
+}
+
+func (settings *GlobalClusterScalingModel) autoscalingPolicy() *GlobalClusterAutoscalingPolicy {
+	if settings == nil || settings.DynamicScaling == nil {
+		return nil
+	}
+	minimum := terraformInt64Pointer(settings.DynamicScaling.Min)
+	maximum := terraformInt64Pointer(settings.DynamicScaling.Max)
+	if minimum == nil || maximum == nil {
+		return nil
+	}
+	return &GlobalClusterAutoscalingPolicy{Min: minimum, Max: maximum}
+}
+
+func terraformInt64Pointer(value types.Int64) *int64 {
+	if value.IsNull() || value.IsUnknown() {
+		return nil
+	}
+	converted := value.ValueInt64()
+	return &converted
+}
+
+func globalClusterScalingModel(policy *GlobalClusterAutoscalingPolicy) *GlobalClusterScalingModel {
+	if policy == nil || policy.Min == nil || policy.Max == nil {
+		return nil
+	}
+	return &GlobalClusterScalingModel{
+		DynamicScaling: &GlobalClusterDynamicScalingModel{
+			Min: types.Int64Value(*policy.Min),
+			Max: types.Int64Value(*policy.Max),
+		},
+	}
 }
 
 func globalClusterMembersFromDomain(apiMembers []GlobalClusterMember, current []GlobalClusterMemberModel) []GlobalClusterMemberModel {
@@ -68,7 +129,7 @@ func globalClusterMembersFromDomain(apiMembers []GlobalClusterMember, current []
 
 	result := make([]GlobalClusterMemberModel, 0, len(primaryMembers)+len(secondaryMembers))
 	for _, primary := range primaryMembers {
-		result = append(result, globalClusterMemberModel(primary))
+		result = append(result, globalClusterMemberModel(primary, configuredGlobalClusterMember(primary, current)))
 	}
 
 	usedSecondaries := make([]bool, len(secondaryMembers))
@@ -78,12 +139,12 @@ func globalClusterMembersFromDomain(apiMembers []GlobalClusterMember, current []
 			continue
 		}
 		usedSecondaries[matchedIndex] = true
-		result = append(result, globalClusterMemberModel(secondaryMembers[matchedIndex]))
+		result = append(result, globalClusterMemberModel(secondaryMembers[matchedIndex], &configuredMember))
 	}
 
 	for i, member := range secondaryMembers {
 		if !usedSecondaries[i] {
-			result = append(result, globalClusterMemberModel(member))
+			result = append(result, globalClusterMemberModel(member, nil))
 		}
 	}
 	return result
@@ -115,12 +176,29 @@ func findGlobalClusterMemberIndex(members []GlobalClusterMember, used []bool, co
 	return -1
 }
 
-func globalClusterMemberModel(member GlobalClusterMember) GlobalClusterMemberModel {
+func configuredGlobalClusterMember(member GlobalClusterMember, configured []GlobalClusterMemberModel) *GlobalClusterMemberModel {
+	for i := range configured {
+		if configured[i].ClusterName.ValueString() == member.ClusterName && configured[i].RegionID.ValueString() == member.RegionID {
+			return &configured[i]
+		}
+	}
+	return nil
+}
+
+func globalClusterMemberModel(member GlobalClusterMember, configured *GlobalClusterMemberModel) GlobalClusterMemberModel {
+	replica := types.Int64Value(member.Replica)
+	if member.Replica < 1 {
+		replica = types.Int64Value(1)
+		if configured != nil && !configured.Replica.IsNull() && !configured.Replica.IsUnknown() {
+			replica = configured.Replica
+		}
+	}
 	return GlobalClusterMemberModel{
 		ClusterID:   types.StringValue(member.ClusterID),
 		ClusterName: types.StringValue(member.ClusterName),
 		RegionID:    types.StringValue(member.RegionID),
 		Role:        types.StringValue(string(member.Role)),
 		Status:      types.StringValue(member.Status),
+		Replica:     replica,
 	}
 }

--- a/internal/global_cluster/resource_model_test.go
+++ b/internal/global_cluster/resource_model_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestGlobalClusterMembersFromDomainFillsComputedFieldsAndPreservesSecondaryOrder(t *testing.T) {
 	current := []GlobalClusterMemberModel{
-		{ClusterName: types.StringValue("secondary-eu"), RegionID: types.StringValue("aws-eu-west-1")},
-		{ClusterName: types.StringValue("secondary-ap"), RegionID: types.StringValue("aws-ap-southeast-1")},
-		{ClusterName: types.StringValue("primary-a"), RegionID: types.StringValue("aws-us-west-2")},
+		{ClusterName: types.StringValue("secondary-eu"), RegionID: types.StringValue("aws-eu-west-1"), Replica: types.Int64Value(2)},
+		{ClusterName: types.StringValue("secondary-ap"), RegionID: types.StringValue("aws-ap-southeast-1"), Replica: types.Int64Value(1)},
+		{ClusterName: types.StringValue("primary-a"), RegionID: types.StringValue("aws-us-west-2"), Replica: types.Int64Value(3)},
 	}
 	apiMembers := []GlobalClusterMember{
 		{ClusterID: "in01-primary", ClusterName: "primary-a", RegionID: "aws-us-west-2", Role: GlobalClusterMemberRolePrimary, Status: "RUNNING"},
@@ -28,6 +28,9 @@ func TestGlobalClusterMembersFromDomainFillsComputedFieldsAndPreservesSecondaryO
 	if got[0].ClusterID.ValueString() != "in01-primary" || got[0].Role.ValueString() != "PRIMARY" || got[0].Status.ValueString() != "RUNNING" {
 		t.Fatalf("primary was not kept first and hydrated: %+v", got[0])
 	}
+	if got[0].Replica.ValueInt64() != 3 || got[1].Replica.ValueInt64() != 2 || got[2].Replica.ValueInt64() != 1 || got[3].Replica.ValueInt64() != 1 {
+		t.Fatalf("member replicas were not preserved/defaulted: %+v", got)
+	}
 	if got[1].ClusterID.ValueString() != "in01-secondary" || got[1].Role.ValueString() != "SECONDARY" {
 		t.Fatalf("first secondary did not follow configured order: %+v", got[1])
 	}
@@ -36,6 +39,76 @@ func TestGlobalClusterMembersFromDomainFillsComputedFieldsAndPreservesSecondaryO
 	}
 	if got[3].ClusterName.ValueString() != "secondary-au" || got[3].ClusterID.ValueString() != "in01-secondary-au" {
 		t.Fatalf("api-only secondary was not appended: %+v", got[3])
+	}
+}
+
+func TestApplyGlobalClusterPopulatesAutoscalingAndMemberReplicas(t *testing.T) {
+	ctx := context.Background()
+	model := GlobalClusterResourceModel{
+		CUSize: types.Int64Unknown(),
+		Cluster: []GlobalClusterMemberModel{
+			{ClusterName: types.StringValue("primary-a"), RegionID: types.StringValue("aws-us-west-2"), Replica: types.Int64Unknown()},
+			{ClusterName: types.StringValue("secondary-eu"), RegionID: types.StringValue("aws-eu-west-1"), Replica: types.Int64Unknown()},
+		},
+	}
+	cuMin, cuMax := int64(4), int64(8)
+	replicaMin, replicaMax := int64(1), int64(3)
+	var diagnostics diag.Diagnostics
+	model.applyGlobalCluster(ctx, &GlobalCluster{
+		GlobalClusterID:   "glo-1",
+		GlobalClusterName: "global-a",
+		ProjectID:         "proj-1",
+		RegionIDs:         []string{"aws-us-west-2", "aws-eu-west-1"},
+		CUType:            "Performance-optimized",
+		Autoscaling: GlobalClusterAutoscaling{
+			CU:      &GlobalClusterAutoscalingPolicy{Min: &cuMin, Max: &cuMax},
+			Replica: &GlobalClusterAutoscalingPolicy{Min: &replicaMin, Max: &replicaMax},
+		},
+		Clusters: []GlobalClusterMember{
+			{ClusterID: "in01-primary", ClusterName: "primary-a", RegionID: "aws-us-west-2", Role: GlobalClusterMemberRolePrimary, Status: "RUNNING", Replica: 2},
+			{ClusterID: "in01-secondary", ClusterName: "secondary-eu", RegionID: "aws-eu-west-1", Role: GlobalClusterMemberRoleSecondary, Status: "RUNNING", Replica: 1},
+		},
+	}, diagnostics.Append)
+
+	if diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diagnostics.Errors()[0].Summary())
+	}
+	if !model.CUSize.IsNull() {
+		t.Fatalf("cu_size must be null under CU autoscaling, got %s", model.CUSize.String())
+	}
+	if model.CUSettings == nil || model.CUSettings.DynamicScaling.Min.ValueInt64() != 4 || model.CUSettings.DynamicScaling.Max.ValueInt64() != 8 {
+		t.Fatalf("unexpected CU settings: %+v", model.CUSettings)
+	}
+	if model.ReplicaSettings == nil || model.ReplicaSettings.DynamicScaling.Min.ValueInt64() != 1 || model.ReplicaSettings.DynamicScaling.Max.ValueInt64() != 3 {
+		t.Fatalf("unexpected replica settings: %+v", model.ReplicaSettings)
+	}
+	if model.Cluster[0].Replica.ValueInt64() != 2 || model.Cluster[1].Replica.ValueInt64() != 1 {
+		t.Fatalf("unexpected member replicas: %+v", model.Cluster)
+	}
+}
+
+func TestGlobalClusterResourceModelBuildsCreateAutoscaling(t *testing.T) {
+	model := GlobalClusterResourceModel{
+		CUSettings: &GlobalClusterScalingModel{DynamicScaling: &GlobalClusterDynamicScalingModel{
+			Min: types.Int64Value(4),
+			Max: types.Int64Value(8),
+		}},
+		ReplicaSettings: &GlobalClusterScalingModel{DynamicScaling: &GlobalClusterDynamicScalingModel{
+			Min: types.Int64Value(1),
+			Max: types.Int64Value(3),
+		}},
+		Cluster: []GlobalClusterMemberModel{
+			{ClusterName: types.StringValue("primary-a"), RegionID: types.StringValue("aws-us-west-2"), Replica: types.Int64Value(2)},
+			{ClusterName: types.StringValue("secondary-eu"), RegionID: types.StringValue("aws-eu-west-1"), Replica: types.Int64Value(1)},
+		},
+	}
+	autoscaling := model.autoscaling()
+	if autoscaling.CU == nil || *autoscaling.CU.Min != 4 || *autoscaling.CU.Max != 8 || autoscaling.Replica == nil || *autoscaling.Replica.Max != 3 {
+		t.Fatalf("unexpected autoscaling: %+v", autoscaling)
+	}
+	members := model.memberSpecs()
+	if len(members) != 2 || members[0].Replica == nil || *members[0].Replica != 2 || members[1].Replica == nil || *members[1].Replica != 1 {
+		t.Fatalf("unexpected member specs: %+v", members)
 	}
 }
 

--- a/internal/global_cluster/resource_test.go
+++ b/internal/global_cluster/resource_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,6 +114,18 @@ func TestGlobalClusterResourceSchemaDoesNotPreserveRegionIDsDuringPlanning(t *te
 	}
 }
 
+func TestGlobalClusterResourceRequiresExactlyOneCUConfiguration(t *testing.T) {
+	ctx := context.Background()
+	validators := newGlobalClusterResource().ConfigValidators(ctx)
+	if len(validators) != 1 {
+		t.Fatalf("ConfigValidators length = %d, want 1", len(validators))
+	}
+	description := validators[0].Description(ctx)
+	if !strings.Contains(description, "cu_size") || !strings.Contains(description, "cu_settings") {
+		t.Fatalf("unexpected validator description: %q", description)
+	}
+}
+
 func testGlobalClusterPlan(t *testing.T, ctx context.Context, schema rschema.Schema, model GlobalClusterResourceModel) tfsdk.Plan {
 	t.Helper()
 	plan := tfsdk.Plan{Schema: schema}
@@ -148,6 +161,19 @@ func globalClusterJSONResponse(t *testing.T, statusCode int, body any) *http.Res
 
 func describeGlobalClusterPayload(cuSize int) map[string]any {
 	payload, _, _ := describeGlobalClusterPayloadParts(cuSize)
+	return payload
+}
+
+func describeGlobalClusterAutoscalingPayload() map[string]any {
+	payload, data, clusters := describeGlobalClusterPayloadParts(0)
+	delete(data, "cuSize")
+	data["autoscaling"] = map[string]any{
+		"cu":      map[string]any{"min": 4, "max": 8},
+		"replica": map[string]any{"min": 1, "max": 3},
+	}
+	clusters[0]["replica"] = 2
+	clusters[1]["replica"] = 1
+	clusters[2]["replica"] = 2
 	return payload
 }
 
@@ -400,6 +426,92 @@ func TestGlobalClusterResourceCreateCreatesAndHydratesState(t *testing.T) {
 	}
 	if state.CreateJobID.ValueString() != "job-create-1" {
 		t.Fatalf("unexpected create job id=%s", state.CreateJobID.ValueString())
+	}
+}
+
+func TestGlobalClusterResourceCreateWithAutoscalingAndMemberReplicas(t *testing.T) {
+	ctx := context.Background()
+	testGlobalClusterPostCreateDescribeDelay(t, 0)
+	resource := newTestGlobalClusterResource(t, func(call int, req *http.Request, body []byte) (*http.Response, error) {
+		switch call {
+		case 1:
+			var createReq zilliz.CreateGlobalClusterParams
+			if err := json.Unmarshal(body, &createReq); err != nil {
+				t.Fatalf("Unmarshal create request: %v", err)
+			}
+			if req.Method != http.MethodPost || req.URL.Path != "/v2/globalClusters/create" || createReq.CuSize != 0 {
+				t.Fatalf("unexpected create request %s %s %+v", req.Method, req.URL.Path, createReq)
+			}
+			if createReq.Autoscaling == nil || createReq.Autoscaling.CU == nil || createReq.Autoscaling.Replica == nil || *createReq.Autoscaling.CU.Max != 8 || *createReq.Autoscaling.Replica.Max != 3 {
+				t.Fatalf("unexpected autoscaling request: %+v", createReq.Autoscaling)
+			}
+			if createReq.PrimaryCluster.Replica == nil || *createReq.PrimaryCluster.Replica != 2 || createReq.SecondaryClusters[0].Replica == nil || *createReq.SecondaryClusters[0].Replica != 1 {
+				t.Fatalf("unexpected member replica request: primary=%+v secondaries=%+v", createReq.PrimaryCluster, createReq.SecondaryClusters)
+			}
+			return globalClusterJSONResponse(t, http.StatusOK, map[string]any{"code": 0, "data": map[string]any{
+				"globalClusterId": "glo-1", "username": "db_admin", "password": "password", "jobId": "job-create-1",
+			}}), nil
+		case 2:
+			return globalClusterJSONResponse(t, http.StatusOK, describeGlobalClusterAutoscalingPayload()), nil
+		default:
+			return nil, fmt.Errorf("unexpected call %d", call)
+		}
+	})
+	schema := testGlobalClusterResourceSchema(t, resource)
+	plan := testGlobalClusterPlan(t, ctx, schema, GlobalClusterResourceModel{
+		ID:                types.StringUnknown(),
+		GlobalClusterName: types.StringValue("global-a"),
+		ProjectID:         types.StringValue("proj-1"),
+		CUType:            types.StringValue("Performance-optimized"),
+		CUSize:            types.Int64Null(),
+		CUSettings: &GlobalClusterScalingModel{DynamicScaling: &GlobalClusterDynamicScalingModel{
+			Min: types.Int64Value(4), Max: types.Int64Value(8),
+		}},
+		ReplicaSettings: &GlobalClusterScalingModel{DynamicScaling: &GlobalClusterDynamicScalingModel{
+			Min: types.Int64Value(1), Max: types.Int64Value(3),
+		}},
+		Cluster: []GlobalClusterMemberModel{
+			{ClusterID: types.StringUnknown(), ClusterName: types.StringValue("primary-a"), RegionID: types.StringValue("aws-us-west-2"), Replica: types.Int64Value(2), Role: types.StringUnknown(), Status: types.StringUnknown()},
+			{ClusterID: types.StringUnknown(), ClusterName: types.StringValue("secondary-eu"), RegionID: types.StringValue("aws-eu-west-1"), Replica: types.Int64Value(1), Role: types.StringUnknown(), Status: types.StringUnknown()},
+			{ClusterID: types.StringUnknown(), ClusterName: types.StringValue("secondary-ap"), RegionID: types.StringValue("aws-ap-southeast-1"), Replica: types.Int64Value(2), Role: types.StringUnknown(), Status: types.StringUnknown()},
+		},
+		ConnectAddress: types.StringUnknown(),
+		CreateTime:     types.StringUnknown(),
+		RegionIDs:      types.ListUnknown(types.StringType),
+		Username:       types.StringUnknown(),
+		Password:       types.StringUnknown(),
+		CreateJobID:    types.StringUnknown(),
+	})
+
+	var resp fwresource.CreateResponse
+	resp.State = tfsdk.State{Schema: schema}
+	resource.Create(ctx, fwresource.CreateRequest{Plan: plan}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create diagnostics: %s: %s", resp.Diagnostics.Errors()[0].Summary(), resp.Diagnostics.Errors()[0].Detail())
+	}
+	var state GlobalClusterResourceModel
+	if diags := resp.State.Get(ctx, &state); diags.HasError() {
+		t.Fatalf("State.Get diagnostics: %s", diags.Errors()[0].Summary())
+	}
+	if !state.CUSize.IsNull() || state.CUSettings == nil || state.CUSettings.DynamicScaling.Max.ValueInt64() != 8 {
+		t.Fatalf("unexpected CU autoscaling state: cu_size=%s settings=%+v", state.CUSize.String(), state.CUSettings)
+	}
+	if state.ReplicaSettings == nil || state.ReplicaSettings.DynamicScaling.Max.ValueInt64() != 3 {
+		t.Fatalf("unexpected replica autoscaling state: %+v", state.ReplicaSettings)
+	}
+	if state.Cluster[0].Replica.ValueInt64() != 2 || state.Cluster[1].Replica.ValueInt64() != 1 || state.Cluster[2].Replica.ValueInt64() != 2 {
+		t.Fatalf("unexpected member replica state: %+v", state.Cluster)
+	}
+}
+
+func TestValidateGlobalClusterAutoscalingRejectsInvertedRange(t *testing.T) {
+	err := validateGlobalClusterAutoscaling(GlobalClusterResourceModel{
+		CUSettings: &GlobalClusterScalingModel{DynamicScaling: &GlobalClusterDynamicScalingModel{
+			Min: types.Int64Value(8), Max: types.Int64Value(4),
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected invalid CU autoscaling range")
 	}
 }
 
@@ -704,6 +816,11 @@ func TestGlobalClusterResourceDeleteRemovesSecondariesBeforePrimary(t *testing.T
 			}
 			return globalClusterJSONResponse(t, http.StatusOK, describeGlobalClusterPayload(4)), nil
 		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v2/globalClusters/glo-1" {
+				t.Fatalf("check primary before first secondary delete %s %s", req.Method, req.URL.Path)
+			}
+			return globalClusterJSONResponse(t, http.StatusOK, describeGlobalClusterPayload(4)), nil
+		case 3:
 			if req.Method != http.MethodDelete || req.URL.Path != "/v2/globalClusters/glo-1/clusters/in01-secondary" {
 				t.Fatalf("delete first secondary %s %s", req.Method, req.URL.Path)
 			}
@@ -711,12 +828,12 @@ func TestGlobalClusterResourceDeleteRemovesSecondariesBeforePrimary(t *testing.T
 				"code": 0,
 				"data": map[string]any{"globalClusterId": "glo-1", "clusterId": "in01-secondary", "prompt": "deleted"},
 			}), nil
-		case 3:
+		case 4:
 			if req.Method != http.MethodGet || req.URL.Path != "/v2/globalClusters/glo-1" {
-				t.Fatalf("describe after first secondary deleted %s %s", req.Method, req.URL.Path)
+				t.Fatalf("check primary before second secondary delete %s %s", req.Method, req.URL.Path)
 			}
 			return globalClusterJSONResponse(t, http.StatusOK, describeGlobalClusterPayloadWithoutSecondaryEU(4)), nil
-		case 4:
+		case 5:
 			if req.Method != http.MethodDelete || req.URL.Path != "/v2/globalClusters/glo-1/clusters/in01-secondary-ap" {
 				t.Fatalf("delete second secondary %s %s", req.Method, req.URL.Path)
 			}
@@ -724,14 +841,9 @@ func TestGlobalClusterResourceDeleteRemovesSecondariesBeforePrimary(t *testing.T
 				"code": 0,
 				"data": map[string]any{"globalClusterId": "glo-1", "clusterId": "in01-secondary-ap", "prompt": "deleted"},
 			}), nil
-		case 5:
-			if req.Method != http.MethodGet || req.URL.Path != "/v2/globalClusters/glo-1" {
-				t.Fatalf("describe after second secondary deleted %s %s", req.Method, req.URL.Path)
-			}
-			return globalClusterJSONResponse(t, http.StatusOK, describeGlobalClusterPayloadWithoutSecondaries()), nil
 		case 6:
 			if req.Method != http.MethodGet || req.URL.Path != "/v2/globalClusters/glo-1" {
-				t.Fatalf("describe primary deletable %s %s", req.Method, req.URL.Path)
+				t.Fatalf("describe after second secondary deleted %s %s", req.Method, req.URL.Path)
 			}
 			return globalClusterJSONResponse(t, http.StatusOK, describeGlobalClusterPayloadWithoutSecondaries()), nil
 		case 7:

--- a/internal/global_cluster/store.go
+++ b/internal/global_cluster/store.go
@@ -29,6 +29,7 @@ func (s *globalClusterStore) Create(ctx context.Context, command CreateGlobalClu
 		ProjectId:         command.ProjectID,
 		CuType:            command.CUType,
 		CuSize:            int(command.CUSize),
+		Autoscaling:       autoscalingParam(command.Autoscaling),
 		PrimaryCluster:    primary,
 		SecondaryClusters: secondaries,
 	})
@@ -70,7 +71,23 @@ func memberParamsForCreate(members []GlobalClusterMemberSpec) (zilliz.GlobalClus
 	if len(members) == 0 {
 		return zilliz.GlobalClusterMemberParams{}, nil
 	}
-	return memberParam(members[0]), memberParams(members[1:])
+	return createMemberParam(members[0]), createMemberParams(members[1:])
+}
+
+func createMemberParams(members []GlobalClusterMemberSpec) []zilliz.GlobalClusterMemberParams {
+	result := make([]zilliz.GlobalClusterMemberParams, 0, len(members))
+	for _, member := range members {
+		result = append(result, createMemberParam(member))
+	}
+	return result
+}
+
+func createMemberParam(member GlobalClusterMemberSpec) zilliz.GlobalClusterMemberParams {
+	return zilliz.GlobalClusterMemberParams{
+		ClusterName: member.ClusterName,
+		RegionId:    member.RegionID,
+		Replica:     intPointer(member.Replica),
+	}
 }
 
 func memberParams(members []GlobalClusterMemberSpec) []zilliz.GlobalClusterMemberParams {
@@ -83,4 +100,32 @@ func memberParams(members []GlobalClusterMemberSpec) []zilliz.GlobalClusterMembe
 
 func memberParam(member GlobalClusterMemberSpec) zilliz.GlobalClusterMemberParams {
 	return zilliz.GlobalClusterMemberParams{ClusterName: member.ClusterName, RegionId: member.RegionID}
+}
+
+func autoscalingParam(autoscaling GlobalClusterAutoscaling) *zilliz.AutoscalingConfig {
+	if autoscaling.CU == nil && autoscaling.Replica == nil {
+		return nil
+	}
+	return &zilliz.AutoscalingConfig{
+		CU:      autoscalingPolicyParam(autoscaling.CU),
+		Replica: autoscalingPolicyParam(autoscaling.Replica),
+	}
+}
+
+func autoscalingPolicyParam(policy *GlobalClusterAutoscalingPolicy) *zilliz.AutoscalingPolicy {
+	if policy == nil {
+		return nil
+	}
+	return &zilliz.AutoscalingPolicy{
+		Min: intPointer(policy.Min),
+		Max: intPointer(policy.Max),
+	}
+}
+
+func intPointer(value *int64) *int {
+	if value == nil {
+		return nil
+	}
+	converted := int(*value)
+	return &converted
 }

--- a/internal/global_cluster/store_test.go
+++ b/internal/global_cluster/store_test.go
@@ -75,6 +75,62 @@ func TestStoreCreateAllowsEmptyMembersForBackendValidation(t *testing.T) {
 	}
 }
 
+func TestStoreCreateSendsAutoscalingAndMemberReplicas(t *testing.T) {
+	store := NewGlobalClusterStore(newStoreTestClient(t, func(call int, req *http.Request, body []byte) (*http.Response, error) {
+		if call != 1 || req.Method != http.MethodPost || req.URL.Path != "/v2/globalClusters/create" {
+			t.Fatalf("unexpected request %d %s %s", call, req.Method, req.URL.Path)
+		}
+		var createReq zilliz.CreateGlobalClusterParams
+		if err := json.Unmarshal(body, &createReq); err != nil {
+			t.Fatalf("Unmarshal create request: %v", err)
+		}
+		if createReq.CuSize != 0 {
+			t.Fatalf("cuSize must be omitted for CU autoscaling, got %d", createReq.CuSize)
+		}
+		if createReq.Autoscaling == nil || createReq.Autoscaling.CU == nil || createReq.Autoscaling.Replica == nil {
+			t.Fatalf("autoscaling policies missing: %+v", createReq.Autoscaling)
+		}
+		if *createReq.Autoscaling.CU.Min != 4 || *createReq.Autoscaling.CU.Max != 8 {
+			t.Fatalf("unexpected CU autoscaling: %+v", createReq.Autoscaling.CU)
+		}
+		if *createReq.Autoscaling.Replica.Min != 1 || *createReq.Autoscaling.Replica.Max != 3 {
+			t.Fatalf("unexpected replica autoscaling: %+v", createReq.Autoscaling.Replica)
+		}
+		if createReq.PrimaryCluster.Replica == nil || *createReq.PrimaryCluster.Replica != 2 {
+			t.Fatalf("unexpected primary replica: %+v", createReq.PrimaryCluster)
+		}
+		if len(createReq.SecondaryClusters) != 1 || createReq.SecondaryClusters[0].Replica == nil || *createReq.SecondaryClusters[0].Replica != 1 {
+			t.Fatalf("unexpected secondary replicas: %+v", createReq.SecondaryClusters)
+		}
+		return storeJSONResponse(t, http.StatusOK, map[string]any{"code": 0, "data": map[string]any{
+			"globalClusterId": "glo-1", "username": "db_admin", "password": "secret", "jobId": "job-1",
+		}}), nil
+	}))
+
+	cuMin, cuMax := int64(4), int64(8)
+	replicaMin, replicaMax := int64(1), int64(3)
+	primaryReplica, secondaryReplica := int64(2), int64(1)
+	created, err := store.Create(context.Background(), CreateGlobalClusterCommand{
+		GlobalClusterName: "global-a",
+		ProjectID:         "proj-1",
+		CUType:            "Performance-optimized",
+		Autoscaling: GlobalClusterAutoscaling{
+			CU:      &GlobalClusterAutoscalingPolicy{Min: &cuMin, Max: &cuMax},
+			Replica: &GlobalClusterAutoscalingPolicy{Min: &replicaMin, Max: &replicaMax},
+		},
+		Members: []GlobalClusterMemberSpec{
+			{ClusterName: "primary-a", RegionID: "aws-us-west-2", Replica: &primaryReplica},
+			{ClusterName: "secondary-eu", RegionID: "aws-eu-west-1", Replica: &secondaryReplica},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create err: %v", err)
+	}
+	if created.GlobalClusterID != "glo-1" || created.JobID != "job-1" {
+		t.Fatalf("unexpected result: %+v", created)
+	}
+}
+
 func TestStoreDescribeReturnsDomainModel(t *testing.T) {
 	store := NewGlobalClusterStore(newStoreTestClient(t, func(call int, req *http.Request, body []byte) (*http.Response, error) {
 		if call != 1 || req.Method != http.MethodGet || req.URL.Path != "/v2/globalClusters/glo-1" {
@@ -84,7 +140,11 @@ func TestStoreDescribeReturnsDomainModel(t *testing.T) {
 			"globalClusterId": "glo-1", "globalClusterName": "global-a", "projectId": "proj-1",
 			"regionIds": []string{"aws-us-west-2"}, "cuType": "Performance-optimized", "cuSize": 4,
 			"connectAddress": "https://glo-1.global-cluster.vectordb.zillizcloud.com", "createTime": "2026-06-04T10:00:00Z",
-			"clusters": []map[string]any{{"clusterId": "in01-primary", "clusterName": "primary-a", "regionId": "aws-us-west-2", "role": "PRIMARY", "status": "RUNNING"}},
+			"autoscaling": map[string]any{
+				"cu":      map[string]any{"min": 4, "max": 8},
+				"replica": map[string]any{"min": 1, "max": 3},
+			},
+			"clusters": []map[string]any{{"clusterId": "in01-primary", "clusterName": "primary-a", "regionId": "aws-us-west-2", "role": "PRIMARY", "status": "RUNNING", "replica": 2}},
 		}}), nil
 	}))
 
@@ -94,6 +154,12 @@ func TestStoreDescribeReturnsDomainModel(t *testing.T) {
 	}
 	if got.GlobalClusterID != "glo-1" || len(got.Clusters) != 1 || got.Clusters[0].ClusterID != "in01-primary" {
 		t.Fatalf("unexpected cluster: %+v", got)
+	}
+	if got.Autoscaling.CU == nil || *got.Autoscaling.CU.Max != 8 || got.Autoscaling.Replica == nil || *got.Autoscaling.Replica.Max != 3 {
+		t.Fatalf("unexpected autoscaling: %+v", got.Autoscaling)
+	}
+	if got.Clusters[0].Replica != 2 {
+		t.Fatalf("unexpected member replica: %+v", got.Clusters[0])
 	}
 }
 
@@ -108,7 +174,7 @@ func TestStoreAddAndDeleteSecondaries(t *testing.T) {
 			if err := json.Unmarshal(body, &addReq); err != nil {
 				t.Fatalf("Unmarshal add request: %v", err)
 			}
-			if len(addReq.SecondaryClusters) != 1 || addReq.SecondaryClusters[0].ClusterName != "secondary-au" {
+			if len(addReq.SecondaryClusters) != 1 || addReq.SecondaryClusters[0].ClusterName != "secondary-au" || addReq.SecondaryClusters[0].Replica != nil {
 				t.Fatalf("unexpected add request: %+v", addReq.SecondaryClusters)
 			}
 			return storeJSONResponse(t, http.StatusOK, map[string]any{"code": 0, "data": map[string]any{"jobId": "job-add-1"}}), nil
@@ -122,7 +188,8 @@ func TestStoreAddAndDeleteSecondaries(t *testing.T) {
 		}
 	}))
 
-	if err := store.AddSecondaryClusters(context.Background(), "glo-1", []GlobalClusterMemberSpec{{ClusterName: "secondary-au", RegionID: "aws-ap-southeast-2"}}); err != nil {
+	replica := int64(2)
+	if err := store.AddSecondaryClusters(context.Background(), "glo-1", []GlobalClusterMemberSpec{{ClusterName: "secondary-au", RegionID: "aws-ap-southeast-2", Replica: &replica}}); err != nil {
 		t.Fatalf("AddSecondaryClusters err: %v", err)
 	}
 	if err := store.DeleteCluster(context.Background(), "glo-1", "in01-secondary"); err != nil {


### PR DESCRIPTION
## Summary
- add `cu_settings` and `replica_settings` to Global Cluster creation
- allow independent initial replica values for primary and secondary members
- refresh autoscaling and member replicas from the describe response
- require replacement when create-only scaling settings or an explicit member replica changes
- preserve the existing add-secondary request shape and update behavior
- update generated resource documentation and example
- stabilize the mock-test job with Terraform 1.8.5 and the mock server default project

## Scope
Create and read only. Existing add/delete-secondary and in-place update behavior is unchanged.

## Validation
- `go test ./internal/global_cluster ./client` passed
- `TF_ACC=1 go test -v ./internal/cluster` passed with Terraform 1.8.5 and the repository mock server (97s)
- `go build -v .` passed
- `go vet ./...` passed
- golangci-lint: 0 issues
- `go generate ./...` is idempotent

A full `go test ./...` still reproduces the pre-existing `TestVolumeResourceDeleteReportsTimeout` failure on the previous PR head; it is outside this change.